### PR TITLE
Feature/inventory wield

### DIFF
--- a/CmdState.cpp
+++ b/CmdState.cpp
@@ -48,6 +48,16 @@ int CCmdState::OnHandleKey( SDL_Keysym *keysym )
 		return 0;
 	}
     
+    // Menu commands allow you to choose from lists of items:
+    // inventory, equipment, stores, chests?, bag of holding, &c
+    if( IsMenuCommand(keysym) )
+    {
+        // Add "modify" to the top of the state stack
+        g_pGame->SetState(STATE_MENU);
+        g_pGame->GetGameState()->HandleKey(keysym);
+        return 0;
+    }
+    
     switch(keysym->sym)
     {
     case SDLK_COMMA:
@@ -58,9 +68,6 @@ int CCmdState::OnHandleKey( SDL_Keysym *keysym )
             OnHandleStairs( keysym );
             return JSUCCESS;
         }
-        break;
-    case SDLK_i:
-        DisplayInventory();
         break;
     default:
         break;
@@ -283,11 +290,7 @@ void CCmdState::UpdatePlayerPos( JVector &vNewPos )
 
 void CCmdState::PickUpItem( JVector &vNewPos )
 {
-    CItem *pItem = g_pGame->GetDungeon()->GetTile(vNewPos)->m_pCurItem;
-    g_pGame->GetMsgs()->Printf( "You have a %s.\n", pItem->GetName() );
-    g_pGame->GetDungeon()->m_llItems->Remove(pItem->m_pllLink, false);
-    pItem->m_pllLink = g_pGame->GetPlayer()->m_llInventory->Add(pItem, pItem->m_id->m_dwIndex);
-    g_pGame->GetDungeon()->GetTile(vNewPos)->m_pCurItem = NULL;
+    g_pGame->GetPlayer()->PickUp(vNewPos);
 }
 
 bool CCmdState::IsModifierNeeded(SDL_Keysym *keysym)
@@ -305,6 +308,23 @@ bool CCmdState::IsModifierNeeded(SDL_Keysym *keysym)
 	}
 
 	return false;
+}
+
+
+bool CCmdState::IsMenuCommand(SDL_Keysym *keysym)
+{
+    switch( keysym->sym )
+    {
+        case SDLK_w:
+        case SDLK_r:
+            return true;
+            break;
+        default:
+            return false;
+            break;
+    }
+    
+    return false;
 }
 
 

--- a/CmdState.h
+++ b/CmdState.h
@@ -24,7 +24,7 @@ protected:
 private:
 	bool IsDirectional(SDL_Keysym *keysym);
 	bool IsModifierNeeded(SDL_Keysym *keysym);
-	bool IsMenuCommand(SDL_Keysym *keysym) {return false;};
+	bool IsMenuCommand(SDL_Keysym *keysym);
 	bool IsMagicCommand(SDL_Keysym *keysym) {return false;};
 	bool IsUseCommand(SDL_Keysym *keysym) {return false;};
 	bool IsHelpCommand(SDL_Keysym *keysym) {return false;};

--- a/Constants.h
+++ b/Constants.h
@@ -16,7 +16,8 @@
 #define STATE_INVALID		-1
 #define STATE_COMMAND		 0
 #define STATE_MODIFY		 1
-#define STATE_MAX			 2
+#define STATE_MENU           2
+#define STATE_MAX            2
 
 // Various statuses that someone could have
 #define STATUS_INVALID		-1
@@ -116,10 +117,11 @@
 #define ITEM_IDX_FOOD           21
 #define ITEM_IDX_MAX            22
 
+#define ITEM_FLAG_CURSED        0x00001000
 #define ITEM_COLOR_MULTI        0x01000000
 
 // Make sure you change below here if you added any flags.
-#define NUM_STRINGS				49
+#define NUM_STRINGS				50
 #include "TextEntry.h"
 class Constants
 {
@@ -186,6 +188,8 @@ public:
         m_StringTable[i++].Init("ITEM_IDX_BOOK",        ITEM_IDX_BOOK);
         m_StringTable[i++].Init("ITEM_IDX_MONEY",        ITEM_IDX_MONEY);
         m_StringTable[i++].Init("ITEM_IDX_FOOD",        ITEM_IDX_FOOD);
+        // Item flags
+        m_StringTable[i++].Init("ITEM_FLAG_CURSED",    ITEM_FLAG_CURSED);
         // Color flags
         m_StringTable[i++].Init("ITEM_COLOR_MULTI",    ITEM_COLOR_MULTI);
     };

--- a/Dungeon.cpp
+++ b/Dungeon.cpp
@@ -648,3 +648,10 @@ JResult CDungeon::Modify( JVector &vPos )
 
 	return JSUCCESS;
 }
+
+CItem *CDungeon::PickUp( JVector &vPickupPos )
+{
+    CItem *pItem = GetTile(vPickupPos)->m_pCurItem;
+    m_llItems->Remove(pItem->m_pllLink, false);
+    return pItem;
+}

--- a/Dungeon.h
+++ b/Dungeon.h
@@ -14,7 +14,7 @@
 //class CItem;
 
 #define DUNG_ZOOM_MIN		4
-#define DUNG_ZOOM_NORMAL	16
+#define DUNG_ZOOM_NORMAL	20
 #define DUNG_ZOOM_MAX		100
 
 class CDungeon

--- a/Dungeon.h
+++ b/Dungeon.h
@@ -101,6 +101,7 @@ public:
     int  IsStairs( JVector &vPos );
 	void RemoveMonster( CMonster *pMon );
 	JResult Modify( JVector &vPos );
+    CItem *PickUp( JVector &vPickupPos );
 protected:
 	JRect m_Rect;
 	JFVector m_vfTranslate;

--- a/Game.cpp
+++ b/Game.cpp
@@ -50,9 +50,15 @@ JResult CGame::Init()
 
 	m_pMsgsDT = new CDisplayText( JRect( 0, 0, 640, 36 ) );
 	m_pMsgsDT->SetFlags(FLAG_TEXT_WRAP_WHITESPACE);
-
-	m_pStatsDT = new CDisplayText( JRect( 0,50,  150,480 ) );
-	m_pStatsDT->SetFlags(FLAG_TEXT_WRAP_WHITESPACE|FLAG_TEXT_BOUNDING_BOX);
+    
+    m_pStatsDT = new CDisplayText( JRect( 0,50,  150,480 ) );
+    m_pStatsDT->SetFlags(FLAG_TEXT_WRAP_WHITESPACE|FLAG_TEXT_BOUNDING_BOX);
+    
+    m_pInvDT = new CDisplayText( JRect( 440,50,  640,340 ) );
+    m_pInvDT->SetFlags(FLAG_TEXT_WRAP_WHITESPACE|FLAG_TEXT_BOUNDING_BOX);
+    
+    m_pEquipDT = new CDisplayText( JRect( 440,345,  640,480 ) );
+    m_pEquipDT->SetFlags(FLAG_TEXT_WRAP_WHITESPACE|FLAG_TEXT_BOUNDING_BOX);
 
 
 	m_pAIMgr = new CAIMgr;
@@ -186,8 +192,10 @@ bool CGame::Update( float fCurTime )
 	
 	// Update the dungeon
 	GetDungeon()->Update(fCurTime);
-	GetMsgs()->Update(fCurTime);
-	GetStats()->Update(fCurTime);
+    GetMsgs()->Update(fCurTime);
+    GetStats()->Update(fCurTime);
+    GetInv()->Update(fCurTime);
+    GetEquip()->Update(fCurTime);
 
 	return true;
 }
@@ -202,8 +210,10 @@ void CGame::Draw()
     // Draw the player
     GetPlayer()->Draw();
     
-	GetMsgs()->Draw();
-	GetStats()->Draw();
+    GetMsgs()->Draw();
+    GetStats()->Draw();
+    GetInv()->Draw();
+    GetEquip()->Draw();
 	
 	GetRender()->PostDraw();
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -9,6 +9,7 @@
 
 #include "CmdState.h"
 #include "ModState.h"
+#include "MenuState.h"
 
 #include "Render.h"
 #include "DisplayText.h"
@@ -28,8 +29,9 @@ m_pCurState(NULL),
 m_pCmdState(NULL),
 m_eCurState(STATE_INVALID)
 {
-	m_pCmdState = new CCmdState;
-	m_pModState = new CModState;
+    m_pCmdState = new CCmdState;
+    m_pModState = new CModState;
+    m_pMenuState = new CMenuState;
 };
 
 JResult CGame::Init()
@@ -121,11 +123,15 @@ void CGame::SetState( int eNewState )
 	{
 	case STATE_COMMAND:
 		m_pCurState = reinterpret_cast<CStateBase *>(m_pCmdState);
-		break;
-	case STATE_MODIFY:
-		m_pCurState = reinterpret_cast<CStateBase *>(m_pModState);
-		break;
+            break;
+    case STATE_MODIFY:
+        m_pCurState = reinterpret_cast<CStateBase *>(m_pModState);
+        break;
+    case STATE_MENU:
+        m_pCurState = reinterpret_cast<CStateBase *>(m_pMenuState);
+        break;
 	default:
+        printf("Tried to change to unknown state.\n");
 		break;
 	}
 }

--- a/Game.h
+++ b/Game.h
@@ -14,6 +14,7 @@ class CDisplayText;
 class CStateBase;
 class CCmdState;
 class CModState;
+class CMenuState;
 class CAIMgr;
 
 class CGame
@@ -52,8 +53,9 @@ protected:
 	CStateBase	 *m_pCurState;
 	int			 m_eCurState;
 
-	CCmdState	*m_pCmdState;
-	CModState	*m_pModState;
+    CCmdState	*m_pCmdState;
+    CModState    *m_pModState;
+    CMenuState   *m_pMenuState;
 
 private:
 	CRender	*m_pRender;

--- a/Game.h
+++ b/Game.h
@@ -30,8 +30,10 @@ public:
 	CRender *GetRender() { return m_pRender; };
 	CDungeon *GetDungeon() { return m_pDungeon; };
 	CPlayer *GetPlayer() { return m_pPlayer; };
-	CDisplayText *GetMsgs() { return m_pMsgsDT; };
-	CDisplayText *GetStats() { return m_pStatsDT; };
+    CDisplayText *GetMsgs() { return m_pMsgsDT; };
+    CDisplayText *GetStats() { return m_pStatsDT; };
+    CDisplayText *GetInv() { return m_pInvDT; };
+    CDisplayText *GetEquip() { return m_pEquipDT; };
 	CAIMgr *GetAIMgr() { return m_pAIMgr; };
 	void Quit( int returncode );
 	void SetState( int eNewState );
@@ -42,8 +44,10 @@ protected:
 	CPlayer		*m_pPlayer;
 	CAIMgr		*m_pAIMgr;
 	
-	CDisplayText *m_pMsgsDT;
-	CDisplayText *m_pStatsDT;
+    CDisplayText *m_pMsgsDT;
+    CDisplayText *m_pStatsDT;
+    CDisplayText *m_pInvDT;
+    CDisplayText *m_pEquipDT;
 	
 	CStateBase	 *m_pCurState;
 	int			 m_eCurState;

--- a/Item.cpp
+++ b/Item.cpp
@@ -34,6 +34,12 @@ JResult CItem::CreateItem( CItemDef *pid )
 void CItem::Init( CItemDef *pid )
 {
     m_id = pid;
+    m_Color.SetColor(m_id->m_Color);
+    if( Util::GetRandom(0,1) )
+    {
+        m_dwFlags |= ITEM_FLAG_CURSED;
+        m_Color.SetColor(255,0,0,255);
+    }
 }
 
 JResult CItem::SpawnItem()
@@ -69,7 +75,7 @@ void CItem::SetColor()
     if( (m_id->m_dwFlags & ITEM_COLOR_MULTI) == ITEM_COLOR_MULTI )
     {
         int which_color = Util::GetRandom(0,m_id->m_Colors->length()-1);
-        (m_id->m_Color).SetColor(*(m_id->m_Colors->GetLink(which_color)->m_lpData));
+        m_Color.SetColor(*(m_id->m_Colors->GetLink(which_color)->m_lpData));
     }
     m_fColorChangeInterval = 0.0f;
 }
@@ -90,7 +96,7 @@ void CItem::Draw()
     SetColor();
     
     //PreDraw();
-    g_pGame->GetDungeon()->m_TileSet->SetTileColor( m_id->m_Color );
+    g_pGame->GetDungeon()->m_TileSet->SetTileColor( m_Color );
     g_pGame->GetDungeon()->m_TileSet->DrawTile( item_tile, m_vPos, vSize, false );
     //PostDraw();
 }

--- a/Item.h
+++ b/Item.h
@@ -75,9 +75,10 @@ public:
     JVector m_vPos;
     CItemDef *m_id;
     CLink<CItem> *m_pllLink;
+    int m_dwFlags; // item cursed, or other specific to this instance, rather than in the general CItemDef
 protected:
     float m_fColorChangeInterval;
-    int m_dwFlags; // item cursed, or other specific to this instance, rather than in the general CItemDef
+    JColor m_Color;
 private:
     
     // Member Functions

--- a/JLinkList.h
+++ b/JLinkList.h
@@ -161,13 +161,24 @@ public:
 		return pLink->prev;
 	};
     
-    CLink <T> *GetLink( int which_link )
+    CLink <T> *GetLink( int which_link, bool bForceValid=true )
     {
         int count = 0;
         CLink <T> *curr_link = GetHead();
+        if(curr_link == NULL) return NULL;
         while( count < which_link )
         {
-            if( curr_link->next == NULL ) return curr_link;
+            if( curr_link->next == NULL )
+            {
+                if( bForceValid )
+                {
+                    return curr_link;
+                }
+                else
+                {
+                    return NULL;
+                }
+            }
             curr_link = GetNext(curr_link);
             count++;
         }

--- a/MenuState.cpp
+++ b/MenuState.cpp
@@ -1,0 +1,244 @@
+#include "MenuState.h"
+
+#include "JMDefs.h"
+#include "DungeonTile.h"
+#include "DisplayText.h"
+#include "Game.h"
+
+#include "Dungeon.h"
+#include "Player.h"
+
+extern CGame *g_pGame;
+
+CMenuState::CMenuState()
+: m_cCommand(0)
+{
+    m_pKeyHandlers[MENU_INIT]    = &CMenuState::OnHandleInit;
+	m_pKeyHandlers[MENU_WIELD]	= &CMenuState::OnHandleWield;
+	m_pKeyHandlers[MENU_UNWIELD]= &CMenuState::OnHandleRemove;
+
+	m_eCurModifier = MENU_INIT;
+	m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
+}
+
+int CMenuState::OnHandleKey(SDL_Keysym *keysym)
+{
+	int retval;
+	retval = ((*this).*(m_pCurKeyHandler))(keysym);
+	return retval;
+}
+
+int CMenuState::OnHandleWield( SDL_Keysym *keysym )
+{
+	int retval;
+	printf( "Handling WIELD menu\n" );
+	retval = OnBaseHandleKey( keysym, MENU_WIELD );
+
+	if( retval == JRESETSTATE )
+	{
+		return 0;
+	}
+
+	if( retval != JSUCCESS )
+	{
+		printf( "Menu cmd still waiting for a alphabetic key: Alpha key not pressed.\n" );
+		g_pGame->GetMsgs()->Printf("Choose an item from inventory(a to z):\n");
+		return 0;
+	}
+
+	// We got a alpha key; do a "wield" of that item
+	printf( "WIELD menu got a selection\n" );
+	if( TestWield() )
+	{
+		if( DoWield() )
+		{
+			g_pGame->GetMsgs()->Printf("You are now wielding the %s.\n", m_pSelected->m_lpData->GetName());
+		}
+		else
+		{
+			g_pGame->GetMsgs()->Printf("The %s slips from your fingers and returns to your pack!\n", m_pSelected->m_lpData->GetName());
+		}
+	}
+	else
+	{
+		g_pGame->GetMsgs()->Printf("You can't wield a %s!\n", m_pSelected->m_lpData->GetName());
+	}
+    m_pSelected = NULL;
+	
+	printf( "WIELD menu resetting game state to COMMAND, WIELD state to INIT\n");
+	// One way or another, we're done with this state now.
+	ResetToState( STATE_COMMAND );
+	return 0;
+}
+
+int CMenuState::OnHandleRemove( SDL_Keysym *keysym )
+{
+	int retval;
+	printf( "Handling REMOVE menu\n" );
+	retval = OnBaseHandleKey( keysym, MENU_UNWIELD );
+
+	if( retval == JRESETSTATE )
+	{
+		return 0;
+	}
+
+    if( retval != JSUCCESS )
+    {
+        printf( "Menu cmd still waiting for a alphabetic key: Alpha key not pressed.\n" );
+        g_pGame->GetMsgs()->Printf("Choose an item from equipment(a to z):\n");
+        return 0;
+    }
+    
+    // We got a alpha key; do a "remove" of that item
+    printf( "REMOVE menu got a selection\n" );
+    if( TestRemove() )
+    {
+        if( DoRemove() )
+        {
+            g_pGame->GetMsgs()->Printf("You take off the %s.\n", m_pSelected->m_lpData->GetName());
+        }
+        else
+        {
+            g_pGame->GetMsgs()->Printf("You can't remove that!\n");
+        }
+        m_pSelected = NULL;
+    }
+    else
+    {
+        g_pGame->GetMsgs()->Printf("The %s is welded to your body!\n", m_pSelected->m_lpData->GetName());
+    }
+    
+    printf( "REMOVE menu resetting game state to COMMAND, REMOVE state to INIT\n");
+    // One way or another, we're done with this state now.
+    ResetToState( STATE_COMMAND );
+    return 0;
+}
+
+int CMenuState::OnHandleInit( SDL_Keysym *keysym )
+{
+	printf( "Initializing menu state...\n" );
+	if( !m_cCommand )
+	{
+		m_cCommand = keysym->sym;
+
+		eMenuModifier mod = MENU_INIT;
+		switch(m_cCommand)
+		{
+		case SDLK_w:
+			mod = MENU_WIELD;
+            g_pGame->GetMsgs()->Printf("Wield which item? [a-z]\n");
+			break;
+		case SDLK_r:
+			mod = MENU_UNWIELD;
+            g_pGame->GetMsgs()->Printf("Remove which item? [a-j]\n");
+			break;
+		default:
+			printf( "There seems to be some kind of mistake; I don't handle mod: %d\n", m_cCommand );
+			ResetToState( STATE_COMMAND );
+			return 0;
+			break;
+		}
+
+		m_eCurModifier = mod;
+		m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
+		return 0;
+	}
+
+	printf( "Error: tried to init modify state when it was already initted...\n" );
+	ResetToState( STATE_COMMAND );
+	// shouldn't get here
+	return JRESETSTATE;
+}
+
+int CMenuState::OnBaseHandleKey( SDL_Keysym *keysym, eMenuModifier whichMenu )
+{
+	if( IsAlpha( keysym ) )
+	{
+		m_pSelected = GetResponse(whichMenu);
+        if( m_pSelected == NULL )
+        {
+            g_pGame->GetMsgs()->Printf("Please select a valid item.\n");
+            
+            return -1;
+        }
+
+		return JSUCCESS;
+	}
+	else if( keysym->sym == SDLK_ESCAPE )
+	{
+		// ESC key gets us out of menu mode
+		ResetToState(STATE_COMMAND);
+		return JRESETSTATE;
+	}
+
+	return -1;
+}
+
+void CMenuState::ResetToState( int newstate )
+{
+	g_pGame->SetState(newstate);
+	m_cCommand = NULL;
+	m_eCurModifier = MENU_INIT;
+	m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
+}
+
+// TODO: Why is this exact code copied from CCmdState?! -- 12.3.2017
+bool CMenuState::IsAlpha(SDL_Keysym *keysym)
+{
+    // All the alphabet keys
+    // have sequential SDLK_ symbols,
+    // so we can handle them with this check
+    if( keysym->sym >= SDLK_a  && keysym->sym <= SDLK_z )
+    {
+        m_dwSelected = keysym->sym - SDLK_a;
+        return true;
+    }
+    
+    return false;
+}
+
+CLink<CItem> *CMenuState::GetResponse(eMenuModifier whichMenu)
+{
+    JLinkList<CItem> *pList = NULL;
+    switch( whichMenu )
+    {
+        case MENU_WIELD:
+            pList = g_pGame->GetPlayer()->m_llInventory;
+            break;
+        case MENU_UNWIELD:
+            pList = g_pGame->GetPlayer()->m_llEquipment;
+            break;
+        default:
+            printf("Can't get response for menu: %d\n", whichMenu);
+            return NULL;
+            break;
+    }
+    CLink<CItem> *pLink = pList->GetLink(m_dwSelected, false);
+    
+    return pLink;
+}
+
+//////////////////////////////////////
+/// command-specific fcns go below
+
+//// Open commands
+bool CMenuState::TestWield()
+{
+	return g_pGame->GetPlayer()->IsWieldable(m_pSelected);
+}
+
+bool CMenuState::DoWield()
+{
+    return g_pGame->GetPlayer()->Wield(m_pSelected);
+}
+
+//// Close commands
+bool CMenuState::TestRemove()
+{
+	return g_pGame->GetPlayer()->IsRemovable(m_pSelected);
+}
+
+bool CMenuState::DoRemove()
+{
+    return g_pGame->GetPlayer()->Remove(m_pSelected);
+}

--- a/MenuState.h
+++ b/MenuState.h
@@ -1,0 +1,62 @@
+#ifndef __MENUSTATE_H__
+#define __MENUSTATE_H__
+#include "JMDefs.h"
+#include "StateBase.h"
+#include "JLinkList.h"
+#include "Item.h"
+
+class CMenuState;
+typedef int (CMenuState::*MenuKeyHandler)(SDL_Keysym *keysym);
+enum eMenuModifier
+{
+	MENU_INVALID=-1,
+	MENU_WIELD=0,
+	MENU_UNWIELD=1,
+    MENU_INIT,
+	MENU_MAX
+};
+
+class CMenuState : public CStateBase
+{
+	// Member Variables
+public:
+protected:
+	char m_cCommand;
+	int m_dwSelected;
+    CLink<CItem> *m_pSelected;
+private:
+	
+	// Member Functions
+public:
+	CMenuState();
+	~CMenuState() {};
+
+
+	virtual void OnUpdate() {};
+	virtual int OnBaseHandleKey( SDL_Keysym *keysym, eMenuModifier whichMenu );
+	virtual int OnHandleKey( SDL_Keysym *keysym );
+protected:
+	bool	IsAlpha(SDL_Keysym *keysym);
+	CLink<CItem>	*GetResponse(eMenuModifier whichMenu);
+	
+private:
+	MenuKeyHandler	m_pKeyHandlers[MENU_MAX];
+	MenuKeyHandler	m_pCurKeyHandler;
+
+	eMenuModifier	m_eCurModifier;
+
+	int OnHandleWield( SDL_Keysym *keysym );
+	int OnHandleRemove( SDL_Keysym *keysym );
+	int OnHandleInit( SDL_Keysym *keysym );
+
+
+	bool TestWield();
+	bool DoWield();
+
+	bool TestRemove();
+	bool DoRemove();
+	
+	void	ResetToState( int newstate );
+};
+
+#endif // __MENUSTATE_H__

--- a/ModState.cpp
+++ b/ModState.cpp
@@ -166,7 +166,7 @@ int CModState::OnHandleInit( SDL_Keysym *keysym )
 	{
 		m_cCommand = keysym->sym;
 
-		eModifier mod = MOD_INIT;
+		eModModifier mod = MOD_INIT;
 		switch(m_cCommand)
 		{
 		case SDLK_o:

--- a/ModState.h
+++ b/ModState.h
@@ -4,8 +4,8 @@
 #include "StateBase.h"
 
 class CModState;
-typedef int (CModState::*KeyHandler)(SDL_Keysym *keysym);
-enum eModifier
+typedef int (CModState::*ModKeyHandler)(SDL_Keysym *keysym);
+enum eModModifier
 {
 	MOD_INVALID=-1,
 	MOD_OPEN=0,
@@ -38,10 +38,10 @@ protected:
 	void	GetDir(SDL_Keysym *keysym, JVector &vDir);
 	
 private:
-	KeyHandler	m_pKeyHandlers[MOD_MAX];
-	KeyHandler	m_pCurKeyHandler;
+	ModKeyHandler	m_pKeyHandlers[MOD_MAX];
+	ModKeyHandler	m_pCurKeyHandler;
 
-	eModifier	m_eCurModifier;
+	eModModifier	m_eCurModifier;
 
 	int OnHandleOpen( SDL_Keysym *keysym );
 	int OnHandleTunnel( SDL_Keysym *keysym );

--- a/Player Docs.txt
+++ b/Player Docs.txt
@@ -1,16 +1,22 @@
 **JMoria**
 
+I'm making this game that I've loved for years, I'll get around to putting in all the features.
+
 *Commands*
 o - open
 c - close
 T - tunnel
-i - inventory
+i - inventory (removed this in favor of just having it onscreen all the time)
+w - wield an item
+r - remove a piece of equipment
 < - go upstairs
 > - go downstairs
 ^c - exit game
 
 *Items*
-Players will automatically pick up items they walk over. Inventory is sorted by item type. 
+Players will automatically pick up items they walk over. Inventory is sorted by item type.
+Wielded items are added to the player's equipment.
+Removed items are added to the player's inventory.
 Someday, Lady Teldra will be a sword in this game. You can count on it.
 
 *Monsters*
@@ -20,8 +26,7 @@ AD&D Monster Manual, 4th printing 1979.
 Fiend Folio and Monster Manual 2. There will probably be some Harry Potter bits, 
 I'll try to remember to keep this list up to date.
 Steven Brust, you are *so* getting some air time on this game. If you ever read this, sir; Thank you very, very much. 
- 
-I'm making this game that I've loved for years, I'll get around to putting in all the features.
+
 The Emperor Lich was really, Really, tough. The badder Faerie Dragons (Purple and up)
 were scary but fun. They gave a lot of loot. There were resists to Fire, Cold, Lightning, and Acid, 
 but none for Poison. This meant really tough creatures who could breathe poison were Very Dangerous.

--- a/Player.cpp
+++ b/Player.cpp
@@ -21,6 +21,8 @@ void CPlayer::Init()
 
 bool CPlayer::Update(float fCurTime)
 {
+    DisplayInventory();
+    DisplayEquipment();
 	return true;
 }
 
@@ -74,12 +76,50 @@ void CPlayer::DisplayInventory()
 {
     CLink<CItem> *pLink = m_llInventory->GetHead();
     CItem *pItem;
-    g_pGame->GetStats()->Printf("You are carrying:\n");
+    g_pGame->GetInv()->Clear();
+    g_pGame->GetInv()->Printf("You are carrying:\n");
+    char cInventoryId = 'a';
     while(pLink != NULL)
     {
         pItem = pLink->m_lpData;
-        g_pGame->GetStats()->Printf("%s\n", pItem->GetName());
+        g_pGame->GetInv()->Printf("%c - %s\n", cInventoryId, pItem->GetName());
+        
+        if( cInventoryId < 'z' )
+        {
+            cInventoryId++;
+        }
+        else
+        {
+            printf("Inventory past first page not shown.\n");
+            break;
+        }
         pLink = m_llInventory->GetNext(pLink);
     }
+    
+}
 
+void CPlayer::DisplayEquipment()
+{
+    CLink<CItem> *pLink = m_llEquipment->GetHead();
+    CItem *pItem;
+    g_pGame->GetEquip()->Clear();
+    g_pGame->GetEquip()->Printf("You are wearing:\n");
+    char cEquipmentId = 'a';
+    while(pLink != NULL)
+    {
+        pItem = pLink->m_lpData;
+        g_pGame->GetEquip()->Printf("%c - %s\n", cEquipmentId, pItem->GetName());
+        
+        if( cEquipmentId < 'z' )
+        {
+            cEquipmentId++;
+        }
+        else
+        {
+            printf("Equipment is limited to N items, one each for specific body parts.\n");
+            break;
+        }
+        pLink = m_llEquipment->GetNext(pLink);
+    }
+    
 }

--- a/Player.h
+++ b/Player.h
@@ -33,8 +33,9 @@ public:
 	bool Update( float fCurTime );
 	void PreDraw();
 	void Draw();
-	void PostDraw();
+    void PostDraw();
     void DisplayInventory();
+    void DisplayEquipment();
     
 	JVector m_vPos;
 	CTileset *m_TileSet;

--- a/Player.h
+++ b/Player.h
@@ -36,6 +36,13 @@ public:
     void PostDraw();
     void DisplayInventory();
     void DisplayEquipment();
+    void PickUp( JVector &vPickupPos );
+    
+    bool IsWieldable(CLink<CItem> *pLink);
+    bool Wield(CLink<CItem> *pItem);
+    
+    bool IsRemovable(CLink<CItem> *pLink);
+    bool Remove(CLink<CItem> *pLink);
     
 	JVector m_vPos;
 	CTileset *m_TileSet;

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Keyboard commands recognized:
 * *o* - open a door
 * *c* - close a door
 * *T* - tunnel through rubble
-* *i* - show character inventory
+* *i* - show character inventory (removed this in favor of just having it onscreen all the time)
+* *w* - wield an item
+* *r* - remove a piece of equipment
 
 Monster definitions are in _Resources/Monsters.txt_
 Item definitions are in _Resources/Items.txt_

--- a/Resources/Items.txt
+++ b/Resources/Items.txt
@@ -234,6 +234,7 @@ Value     1000.0
 Level        20
 Weight         0.2
 Color        <225,50,225,255>
+}
 
 Item <Small Steal Shield>
 {

--- a/WORKLIST.txt
+++ b/WORKLIST.txt
@@ -1,8 +1,7 @@
 JMoria Work List
 ----------------
 DATA / GAMEPLAY:
-- implement DAT file reading (XML format? INI format? passwd format?) for: dungeon, item, savefile
-- Now that monsters.txt can be read, create many new monster defs.
+- implement DAT file reading (XML format? INI format? passwd format?) for: dungeon, races, classes, spells, savefile
 - need to add status effects (e.g. poison)
 - implement "flavored" attacks, e.g. a _BREATHE type should read m_dwFlags to figure out which type of breath (fire, ice, &c)s
 
@@ -33,14 +32,14 @@ ITEMS:
 - ego items [FB] [DB] [WB] [DF] [HA] ...
 - unique items I mean Vlad had to take on a Jenoine, I'm just saying.
 - Maybe uniques can't be found until the character holding them dies.
+- pickaxe / shovel
 
 
 PLAYER:
-- create e)quipment list
-- Player can only hold one of each type (for now)
+- Player can only hold one of each wieldable type (for now; two rings is an enhancement)
 - equipped items enhance player instrinsics; player wears ring, set the intrinsic "isInvisible" on the player.
 - equipped items are used to make attacks and to defend against attacks (raise AC, raise to-hit and damage stats, &c)
-- equippable items restricted to certain subset of all items ITEM_FLAG_EQUIPMENT
+- equippable items restricted to certain subset of all items ITEM_FLAG_EQUIPMENT, instead of hardcoded in CPlayer::Wield.
 
 
 COMBAT:
@@ -76,6 +75,7 @@ FONT / TEXTURE / DISPLAY / COLOR:
   already loaded bitmap?) (what if I want different fonts?)
   (perhaps a tilemgr? maybe just all the DisplayText boxes use the same (set of) fonts?
   foo=new DisplayText(FONT_COURIER, JRect()) maybe)
+- display player intrinsics as part of the texture coloration: stripes for each one, or "LEDs" or something.
 
 
 
@@ -96,13 +96,12 @@ STABILITY:
 - figure out why the game is so rickety?
 - figure out why the framerate seems to tank? unfreed resources? (4/10/03 still a problem? Haven't seen it)
 - 12.5.2017 - B reports occasionally all the text goes black on black, doesn't affect the dungeon, only the overlay.
-- 12.5.2017 - The blue icky thing seems to disappear if the player is too far away? Does this happen to other monsters?
 - 12.5.2017 - getting a lot of intermittent "bad string" complaints; wtf?! like for some reason the string lookup table sometimes isn't working right
 
 
 
 DUNGEON GENERATION: (as of 1.27.06, hardcoded 16x16 dungeon back in)
-- 12.5.2017: in lieu of full dungeon generation, maybe staircases could be implemented next, just respawn the 16x16 dungeon (but with a new monster!) each time... or have a small set of hardcoded dungeons (like the 16x16 but rotated), choose among them. Beginnings of "room type"
+- 12.5.2017: in lieu of full dungeon generation, maybe have a small set of hardcoded dungeons (like the 16x16 but rotated), choose among them. Beginnings of "room type"
 - 1.27.06: hardcoded 16x16 dungeon back in. Get to work on gameplay. SDL crash was in Dungeon->Draw(), where 
   I had hardcoded 256x256 instead of DUNG_WIDTH/HEIGHT. duh.
 - 1.1.05: tried to clean up a little and put the game in a state where it could be worked on. This met little success. 

--- a/WORKLIST.txt
+++ b/WORKLIST.txt
@@ -7,6 +7,42 @@ DATA / GAMEPLAY:
 - implement "flavored" attacks, e.g. a _BREATHE type should read m_dwFlags to figure out which type of breath (fire, ice, &c)s
 
 
+MONSTERS:
+- orcs
+- trolls
+- giants
+- Ettin
+- floating eye
+- Ogre
+- goblin
+- goblin shaman
+- goblin warrior
+- goblin chieftain
+- uruk-hai
+- skeletons / zombies / ghosts / ghoul / wight / vampire / lich
+- novice paladin / ranger / priest / warrior /
+- hobbit (steals your purse and runs away)
+- mind flayer
+- dzur / tiassa / hawk
+- Tiamat
+- You must defeat 17 Warriors from the Hall of Heroes in combat, before you may face Tiamat.
+
+
+ITEMS:
+- Magic items "x of Protection", "y of Resist Fire", but scramble the varieties each game of course.
+- ego items [FB] [DB] [WB] [DF] [HA] ...
+- unique items I mean Vlad had to take on a Jenoine, I'm just saying.
+- Maybe uniques can't be found until the character holding them dies.
+
+
+PLAYER:
+- create e)quipment list
+- Player can only hold one of each type (for now)
+- equipped items enhance player instrinsics; player wears ring, set the intrinsic "isInvisible" on the player.
+- equipped items are used to make attacks and to defend against attacks (raise AC, raise to-hit and damage stats, &c)
+- equippable items restricted to certain subset of all items ITEM_FLAG_EQUIPMENT
+
+
 COMBAT:
 - combat is very hardcoded. make it not so much.
 - implement monster fighting back (might need HP and stuff for that, though)
@@ -14,6 +50,7 @@ COMBAT:
 - should monsters be able to wield items? use potions? pick stuff up off the ground?
 - need to add speed, somehow
 - someday, convert to turn-based, too :)
+
 
 
 ARCHITECTURE:
@@ -24,6 +61,10 @@ ARCHITECTURE:
   saves a % and / per obj, per frame. costs 1 vector/obj.
 - continue to implement CDungeon (current level, CMonster List, CItem List)
 - some way to implement unit tests would be nice.
+- Which routines should be owned by Dungeon? Which by Player? Monster? Item?
+- Need Architecture diagram
+- Need Developer's Guide
+
 
 
 FONT / TEXTURE / DISPLAY / COLOR:
@@ -37,6 +78,7 @@ FONT / TEXTURE / DISPLAY / COLOR:
   foo=new DisplayText(FONT_COURIER, JRect()) maybe)
 
 
+
 ENGINE / RENDERING:
 - Keep the renderer you have for awhile. Concentrate on putting together a solid gameplay demo.
 - Contract art later as needed.
@@ -48,6 +90,7 @@ ENGINE / RENDERING:
 - (Update 12.3.2017) ported to OSX, which required switching to SDL2. Other than rewriting CRender::initSDL(), no major changes. we will are back to where we were when we last left the project (in 2006?). I also moved the code from VSS to Github git@github.com:Rushwind13/JMoria.git .
 
 
+
 STABILITY:
 - be able to close the game properly.
 - figure out why the game is so rickety?
@@ -55,6 +98,7 @@ STABILITY:
 - 12.5.2017 - B reports occasionally all the text goes black on black, doesn't affect the dungeon, only the overlay.
 - 12.5.2017 - The blue icky thing seems to disappear if the player is too far away? Does this happen to other monsters?
 - 12.5.2017 - getting a lot of intermittent "bad string" complaints; wtf?! like for some reason the string lookup table sometimes isn't working right
+
 
 
 DUNGEON GENERATION: (as of 1.27.06, hardcoded 16x16 dungeon back in)

--- a/_JMoria Developer's Guide.md
+++ b/_JMoria Developer's Guide.md
@@ -1,0 +1,23 @@
+#  JMoria Developer's Guide
+
+## Adding a new Monster
+1) If you are creating a new flavor of an existing monster (adding a new type of orc), you just need to:
+        a) edit *Monsters.txt*
+2) If you are creating a new type of monster (no Vogons? a travesty!), you need to:
+        a) edit *Monsters.txt*, then
+        b) add the new *MON_IDX_* type to _Constants.h_, and finally,
+        c) add the new monster's emoji to the *MonIds* list in _Monster.cpp_
+## Adding a new Item
+1) If you are creating a new flavor of an existing item (adding a new type of wand), you just need to:
+a) edit *Items.txt*
+2) If you are creating a new type of item (no Katana? a travesty!), you need to:
+a) editm _Items.txt_, then
+b) add the new *ITEM_IDX_* type to _Constants.h_, and finally,
+c) add the new item's emoji to the *ItemIds* list in _Item.cpp_
+## How to see your new thingy in the game
+1) In _Dungeon.cpp_, you can find *#define RANDOM_MONSTER*,
+2) comment this out, and you can choose which monster from the config you want to see.
+
+similar instruction for items
+
+Create a Pull request on Github when you're satisfied.

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 #include "DisplayText.h"
 //#include "Render.h"
 
-#include "player.h"
+#include "Player.h"
 
 // The global game pointer
 CGame *g_pGame;


### PR DESCRIPTION
Added new screen panels to display Player Inventory and Equipment lists.
Added new game state to handle Menu operations (selecting items from inventory or equipment lists)
Added 'w' (wield) and 'r' (remove) key bindings.
Cannot remove cursed items.