### PR TITLE
fix: Log output

### DIFF
--- a/src/ClockStepState.cpp
+++ b/src/ClockStepState.cpp
@@ -55,12 +55,12 @@ int CClockStepState::OnHandleTick( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "CLOCK still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_WARN, true, "CLOCK still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_INFO, true, "TICK modifier got a valid key\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "TICK modifier got a valid key\n" );
     g_pGame->GetEnd()->Clear();
     DoTick();
 

--- a/src/CmdState.cpp
+++ b/src/CmdState.cpp
@@ -82,7 +82,7 @@ int CCmdState::OnHandleKey( SDL_Keysym *keysym )
         switch( keysym->sym )
         {
         case SDLK_r:
-            JLog( LOG_LEVEL_DEBUG, true, "R)est not implemented yet.\n" );
+            JLog( LOG_LEVEL_WARN, true, "R)est not implemented yet.\n" );
             g_pGame->SetState( STATE_REST );
             g_pGame->GetGameState()->HandleKey( keysym );
             break;
@@ -136,7 +136,7 @@ int CCmdState::OnHandleKey( SDL_Keysym *keysym )
             g_Searching = true;
     break;
     default:
-            JLog( LOG_LEVEL_INFO, true,  "Press ? for help.\n" );
+            JLog( LOG_LEVEL_WARN, true,  "Press ? for help.\n" );
     break;
     }/**/
 

--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -114,7 +114,7 @@ void CDungeon::Init( const char *szBasedir )
 
     m_bDraw = true;
 
-    CreateNewLevel( DUNG_CFG_START_LEVEL );
+    OnChangeLevel( DUNG_CFG_START_LEVEL );
 }
 
 JResult CDungeon::TerminateLevel()
@@ -238,10 +238,11 @@ JResult CDungeon::PlaceStairs( const int desired, const int type )
     while( count < desired )
     {
         bStairsSpawned = false;
-        JLog( LOG_LEVEL_INFO, true, "Trying to spawn stairs type: %d...", type );
+        JLog( LOG_LEVEL_WARN, false, "Trying to spawn stairs type: %d...", type );
         JVector vTryPos;
         while( !bStairsSpawned )
         {
+            JLog( LOG_LEVEL_WARN, false, "." );
             vTryPos.Init( (float)( Util::GetRandom( 0, DUNG_WIDTH - 1 ) ),
                           (float)( Util::GetRandom( 0, DUNG_HEIGHT - 1 ) ) );
 
@@ -254,7 +255,8 @@ JResult CDungeon::PlaceStairs( const int desired, const int type )
             {
                 GetTile( vTryPos )->m_dtd = &m_dtdlist[type];
                 bStairsSpawned = true;
-                JLog( LOG_LEVEL_INFO, false, "Success!\n" );
+                JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n",
+                      VEC_EXPAND( vTryPos ) );
             }
         }
         count++;
@@ -267,7 +269,7 @@ JResult CDungeon::PlaceItems( const int depth )
     m_llItems = new JLinkList<CItem>;
 
     int desired_items = int( m_fOpenFloorArea * DUNG_CFG_ITEMS_PER_LEVEL );
-    JLog( LOG_LEVEL_INFO, true, "Possible spawn points: %0.2f  desired items: %d\n",
+    JLog( LOG_LEVEL_WARN, false, "\nPossible spawn points: %0.2f  desired items: %d\n",
           m_fOpenFloorArea, desired_items );
 
     while( desired_items > 0 )
@@ -280,7 +282,7 @@ JResult CDungeon::PlaceItems( const int depth )
         }
 
         CItemDef *chosen_item = m_llItemDefs->GetLink( which_item )->m_lpData;
-        JLog( LOG_LEVEL_INFO, true, "Choosing item %d, called %s", which_item,
+        JLog( LOG_LEVEL_DEBUG, true, "Choosing item %d, called %s", which_item,
               chosen_item->m_szName );
 
         CItem::CreateItem( chosen_item );
@@ -296,7 +298,7 @@ JResult CDungeon::SpawnMonsters( const int depth )
     m_llMonsters = new JLinkList<CMonster>;
 
     int desired_monsters = int( m_fOpenFloorArea * DUNG_CFG_MONSTERS_PER_LEVEL );
-    JLog( LOG_LEVEL_INFO, true, "Possible spawn points: %0.2f  desired monsters: %d\n",
+    JLog( LOG_LEVEL_WARN, false, "\nPossible spawn points: %0.2f  desired monsters: %d\n",
           m_fOpenFloorArea, desired_monsters );
 
     while( desired_monsters > 0 )
@@ -333,7 +335,7 @@ CMonsterDef *CDungeon::GetMonsterDef( int which_monster )
 bool CDungeon::SpawnMonster( int which_monster )
 {
     CMonsterDef *chosen_monster = GetMonsterDef( which_monster );
-    JLog( LOG_LEVEL_INFO, true, "Choosing monster %d, called %s...", which_monster,
+    JLog( LOG_LEVEL_DEBUG, true, "Choosing monster %d, called %s...", which_monster,
           chosen_monster->m_szName );
 
     CMonster::CreateMonster( chosen_monster );
@@ -385,7 +387,7 @@ int CDungeon::ChooseMonsterForDepth( const int depth )
 
 JResult CDungeon::OnChangeLevel( const int delta )
 {
-    JLog( LOG_LEVEL_INFO, true, "Changing level..." );
+    JLog( LOG_LEVEL_WARN, false, "Changing level...\n" );
     // Clean up old level, then
     TerminateLevel();
 
@@ -393,8 +395,8 @@ JResult CDungeon::OnChangeLevel( const int delta )
     CreateNewLevel( delta );
     g_pGame->GetPlayer()->m_bHasSpawned = false;
     g_pGame->GetPlayer()->SpawnPlayer();
-    JLog( LOG_LEVEL_INFO, true, "done.\n" );
-    JLog( LOG_LEVEL_INFO, true, "You pass through a one-way door, to arrive on level %d.\n",
+    JLog( LOG_LEVEL_WARN, false, "done.\n" );
+    JLog( LOG_LEVEL_WARN, false, "You pass through a one-way door, to arrive on level %d.\n",
           depth );
     g_pGame->GetMsgs()->Printf( "You pass through a one-way door, to arrive on level %d.\n",
                                 depth );
@@ -635,7 +637,7 @@ int CDungeon::IsWalkableFor( JVector &vPos, bool isPlayer )
     CDungeonTile *curTile = GetTile( vPos );
     if( curTile == NULL )
     {
-        JLog( LOG_LEVEL_INFO, true, "Hey! That's a bad tile.\n" );
+        JLog( LOG_LEVEL_ERROR, true, "Hey! That's a bad tile.\n" );
         return false;
     }
     if( curTile->m_pCurMonster != NULL )
@@ -647,7 +649,7 @@ int CDungeon::IsWalkableFor( JVector &vPos, bool isPlayer )
              g_pGame->GetPlayer()->m_vPos == vPos )
     {
         // Monsters colliding with the player can be hazardous to your health.
-        JLog( LOG_LEVEL_INFO, true, "Monster attacking not implemented yet.\n" );
+        JLog( LOG_LEVEL_WARN, true, "Monster attacking not implemented yet.\n" );
         return DUNG_COLL_PLAYER;
     }
     else if( isPlayer && curTile->m_pCurItem != NULL )
@@ -676,7 +678,7 @@ int CDungeon::CanPlaceStairsAt( JVector &vPos )
     CDungeonTile *curTile = GetTile( vPos );
     if( curTile == NULL )
     {
-        JLog( LOG_LEVEL_INFO, true, "Hey! That's a bad tile.\n" );
+        JLog( LOG_LEVEL_ERROR, true, "Hey! That's a bad tile.\n" );
         return false;
     }
 

--- a/src/DungeonMap.cpp
+++ b/src/DungeonMap.cpp
@@ -41,33 +41,33 @@ void CDungeonMap::CreateDungeon( const int depth )
     // Do something with the depth, here...
     if( depth > 100 )
     {
-        JLog( LOG_LEVEL_INFO, true, "You have a bad feeling about this level...\n" );
+        JLog( LOG_LEVEL_WARN, false, "You have a bad feeling about this level...\n" );
     }
     else if( depth > 75 )
     {
-        JLog( LOG_LEVEL_INFO, true, "Just another walk in the park.\n" );
+        JLog( LOG_LEVEL_WARN, false, "Just another walk in the park.\n" );
     }
     else if( depth > 50 )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, false,
               "It is my firm belief that this level contains monsters, of one kind or another.\n" );
     }
     else if( depth > 25 )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, false,
               "This level goes together like wham-a-lamma-lamma and bop-she-bop-she-bop.\n" );
     }
     else if( depth > 10 )
     {
-        JLog( LOG_LEVEL_INFO, true, "What was *that*?!.\n" );
+        JLog( LOG_LEVEL_WARN, false, "What was *that*?!.\n" );
     }
     else if( depth > 5 )
     {
-        JLog( LOG_LEVEL_INFO, true, "Please keep hands and arms inside the carriage.\n" );
+        JLog( LOG_LEVEL_WARN, false, "Please keep hands and arms inside the carriage.\n" );
     }
     else if( depth <= 0 )
     {
-        JLog( LOG_LEVEL_INFO, true, "Error, levels don't go below 0.\n" );
+        JLog( LOG_LEVEL_WARN, false, "Error, levels don't go below 0.\n" );
     }
 #ifdef FIXED_DUNGEON
     //    For setpiece rooms, treasure rooms, &c
@@ -121,7 +121,7 @@ bool CDungeonMap::CheckInterior( const JRect area )
             vCheck.x = x;
             if( GetTile( vCheck )->GetType() != DUNG_IDX_WALL )
             {
-                JLog( LOG_LEVEL_INFO, true,
+                JLog( LOG_LEVEL_DEBUG, true,
                       "interior check failed. Wanted <%d %d, %d %d>, but <%d %d> was %d\n",
                       RECT_EXPAND( area ), x, y, m_dmtTiles[y * DUNG_WIDTH + x].GetType() );
                 return false;
@@ -162,25 +162,25 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
     // TweakBorders(rcCheck, direction);
     if( rcCheck.top <= 0 )
     {
-        JLog( LOG_LEVEL_INFO, true, "border failed: <%d %d, %d %d>, top=0\n",
+        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, top=0\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
     else if( rcCheck.bottom >= DUNG_HEIGHT - 1 )
     {
-        JLog( LOG_LEVEL_INFO, true, "border failed: <%d %d, %d %d>, bottom=max\n",
+        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, bottom=max\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
     else if( rcCheck.left <= 0 )
     {
-        JLog( LOG_LEVEL_INFO, true, "border failed: <%d %d, %d %d>, left=0\n",
+        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, left=0\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
     else if( rcCheck.right >= DUNG_WIDTH - 1 )
     {
-        JLog( LOG_LEVEL_INFO, true, "border failed: <%d %d, %d %d>, right=max\n",
+        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, right=max\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
@@ -188,7 +188,7 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
     JRect rcEdges( rcCheck.left - 1, rcCheck.top - 1, rcCheck.right + 1, rcCheck.bottom + 1 );
     if( !rcEdges.IsInWorld() )
     {
-        JLog( LOG_LEVEL_INFO, true, "border failed: <%d %d, %d %d>, edges fail.\n",
+        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, edges fail.\n",
               RECT_EXPAND( rcEdges ) );
         return false;
     }
@@ -202,7 +202,7 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
             int type = GetTile( vCheck )->GetType();
             if( type != DUNG_IDX_WALL && !IsDoor( type ) )
             {
-                JLog( LOG_LEVEL_INFO, true,
+                JLog( LOG_LEVEL_DEBUG, true,
                       "border check failed. Wanted <%d %d, %d %d>, but <%d %d> was %d\n",
                       RECT_EXPAND( area ), x, y, m_dmtTiles[y * DUNG_WIDTH + x].GetType() );
                 return false;
@@ -502,21 +502,23 @@ void CDungeonMap::AddDoor( const JIVector vHall, int direction )
     // What kind of door?
     int door_type = DUNG_IDX_DOOR;
     int roll = Util::Roll( "1d100" );
+    char flavor[32];
     if( roll <= normal )
     {
+        sprintf( flavor, "" );
         door_type = DUNG_IDX_DOOR;
     }
     else if( roll <= open )
     {
-        JLog( LOG_LEVEL_INFO, true, "Added an open door.\n" );
+        sprintf( flavor, "open " );
         door_type = DUNG_IDX_OPEN_DOOR;
     }
     else
     {
-        JLog( LOG_LEVEL_INFO, true, "Added a secret door.\n" );
+        sprintf( flavor, "secret " );
         door_type = DUNG_IDX_SECRET_DOOR;
     }
-    JLog( LOG_LEVEL_INFO, true, "Placing a %d door at <%d %d>\n", door_type, VEC_EXPAND( vDoor ) );
+    JLog( LOG_LEVEL_WARN, false, "Placing a %sdoor at <%d %d>\n", flavor, VEC_EXPAND( vDoor ) );
     GetTile( vDoor )->SetType( door_type );
 }
 
@@ -551,7 +553,7 @@ CDungeonCreationStep *CDungeonMap::MakeRoomStep( const JIVector &vPos, const int
         if( !dwDone )
         {
             // this one didn't work, need to "un-shift" the rect for the next try.
-            JLog( LOG_LEVEL_INFO, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
+            JLog( LOG_LEVEL_DEBUG, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
                   RECT_EXPAND( pStep->m_rcArea ), RECT_EXPAND( rcTry ) );
             pStep->m_rcArea.Init( rcTry );
         }
@@ -596,7 +598,7 @@ CDungeonCreationStep *CDungeonMap::MakeHallStep( const JIVector &vPos, const int
         if( !dwDone )
         {
             // this one didn't work, need to "un-shift" the rect for the next try.
-            JLog( LOG_LEVEL_INFO, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
+            JLog( LOG_LEVEL_DEBUG, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
                   RECT_EXPAND( pStep->m_rcArea ), RECT_EXPAND( rcTry ) );
             pStep->m_rcArea.Init( rcTry );
         }
@@ -702,7 +704,8 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init(
             pStep->m_rcArea.Left() + ( Util::GetRandom( 0, pStep->m_rcArea.Width() ) ),
             pStep->m_rcArea.Top() - 2 ); // -1... does a room's rect include its walls?
-        JLog( LOG_LEVEL_INFO, true, "[%d>%d]GetWallOrigin creating north %s, starting at <%d %d>\n",
+        JLog( LOG_LEVEL_DEBUG, true,
+              "[%d>%d]GetWallOrigin creating north %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
               VEC_EXPAND( pStep->m_vPos ) );
@@ -711,7 +714,8 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init( pStep->m_rcArea.Left() +
                                 ( Util::GetRandom( 0, pStep->m_rcArea.Width() ) ),
                             pStep->m_rcArea.Bottom() + 2 );
-        JLog( LOG_LEVEL_INFO, true, "[%d>%d]GetWallOrigin creating south %s, starting at <%d %d>\n",
+        JLog( LOG_LEVEL_DEBUG, true,
+              "[%d>%d]GetWallOrigin creating south %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
               VEC_EXPAND( pStep->m_vPos ) );
@@ -720,7 +724,7 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init( pStep->m_rcArea.Left() - 2,
                             pStep->m_rcArea.Top() +
                                 ( Util::GetRandom( 0, pStep->m_rcArea.Height() ) ) );
-        JLog( LOG_LEVEL_INFO, true, "[%d>%d]GetWallOrigin creating west %s, starting at <%d %d>\n",
+        JLog( LOG_LEVEL_DEBUG, true, "[%d>%d]GetWallOrigin creating west %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
               VEC_EXPAND( pStep->m_vPos ) );
@@ -729,7 +733,7 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init( pStep->m_rcArea.Right() + 2,
                             pStep->m_rcArea.Top() +
                                 ( Util::GetRandom( 0, pStep->m_rcArea.Height() ) ) );
-        JLog( LOG_LEVEL_INFO, true, "[%d>%d]GetWallOrigin creating east %s, starting at <%d %d>\n",
+        JLog( LOG_LEVEL_DEBUG, true, "[%d>%d]GetWallOrigin creating east %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
               VEC_EXPAND( pStep->m_vPos ) );
@@ -752,25 +756,25 @@ JIVector &CDungeonMap::GetHallOrigin( CDungeonCreationStep *pStep, int step_type
         pStep->m_vPos.Init( pStep->m_rcArea.Left(),
                             pStep->m_rcArea.Top() -
                                 modifier ); // -1... does a room's rect include its walls?
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_DEBUG, true,
               "[%d>%d]GetHallOrigin creating north hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;
     case DIR_SOUTH:
         pStep->m_vPos.Init( pStep->m_rcArea.Left(), pStep->m_rcArea.Bottom() + modifier );
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_DEBUG, true,
               "[%d>%d]GetHallOrigin creating south hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;
     case DIR_WEST:
         pStep->m_vPos.Init( pStep->m_rcArea.Left() - modifier, pStep->m_rcArea.Top() );
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_DEBUG, true,
               "[%d>%d]GetHallOrigin creating west hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;
     case DIR_EAST:
         pStep->m_vPos.Init( pStep->m_rcArea.Right() + modifier, pStep->m_rcArea.Top() );
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_DEBUG, true,
               "[%d>%d]GetHallOrigin creating east hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;

--- a/src/EndGameState.cpp
+++ b/src/EndGameState.cpp
@@ -77,12 +77,12 @@ int CEndGameState::OnHandleTomb( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "Name cmd still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_WARN, true, "Name cmd still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_INFO, true, "TOMB modifier got a valid key\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "TOMB modifier got a valid key\n" );
     g_pGame->GetEnd()->Clear();
     DoTomb();
 
@@ -108,12 +108,12 @@ int CEndGameState::OnHandleScores( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "Name cmd still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_WARN, true, "Name cmd still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_INFO, true, "SCORES modifier got a valid key\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "SCORES modifier got a valid key\n" );
     g_pGame->GetEnd()->Clear();
     DoScores();
 
@@ -122,7 +122,7 @@ int CEndGameState::OnHandleScores( SDL_Keysym *keysym )
 
 int CEndGameState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_INFO, true, "Initializing endgame state...\n" );
+    JLog( LOG_LEVEL_WARN, true, "Initializing endgame state...\n" );
 
     m_pScore->InitScore();
 

--- a/src/FileParse.cpp
+++ b/src/FileParse.cpp
@@ -175,7 +175,7 @@ CMonsterDef *CDataFile::ReadMonster( CMonsterDef &mdIn )
                 end = strchr( szLine, '>' );
                 if( begin == NULL || end == NULL )
                 {
-                    JLog( LOG_LEVEL_INFO, true, "error parsing attack: effect type not found %s\n",
+                    JLog( LOG_LEVEL_ERROR, true, "error parsing attack: effect type not found %s\n",
                           cur );
                     continue;
                 }
@@ -189,7 +189,7 @@ CMonsterDef *CDataFile::ReadMonster( CMonsterDef &mdIn )
                 end = strchr( cur, '>' );
                 if( begin == NULL || end == NULL )
                 {
-                    JLog( LOG_LEVEL_INFO, true, "error parsing attack: attack type not found %s\n",
+                    JLog( LOG_LEVEL_ERROR, true, "error parsing attack: attack type not found %s\n",
                           cur );
                     continue;
                 }
@@ -217,7 +217,7 @@ CMonsterDef *CDataFile::ReadMonster( CMonsterDef &mdIn )
                 begin = strchr( cur, ',' );
                 if( begin == NULL )
                 {
-                    JLog( LOG_LEVEL_INFO, true, "error parsing attack: damage not found %s\n",
+                    JLog( LOG_LEVEL_ERROR, true, "error parsing attack: damage not found %s\n",
                           cur );
                     continue;
                 }
@@ -265,7 +265,7 @@ CMonsterDef *CDataFile::ReadMonster( CMonsterDef &mdIn )
             }
             else
             {
-                JLog( LOG_LEVEL_INFO, true, "Unparseable line:%s\n", szLine );
+                JLog( LOG_LEVEL_WARN, true, "Unparseable line:%s\n", szLine );
             }
         }
     }
@@ -441,7 +441,7 @@ CItemDef *CDataFile::ReadItem( CItemDef &idIn )
             }
             else
             {
-                JLog( LOG_LEVEL_INFO, true, "Unparseable line:%s\n", szLine );
+                JLog( LOG_LEVEL_WARN, true, "Unparseable line:%s\n", szLine );
             }
         }
     }
@@ -528,7 +528,7 @@ CScore *CDataFile::ReadScore( CScore &sIn )
             }
             else
             {
-                JLog( LOG_LEVEL_INFO, true, "Unparseable line:%s\n", szLine );
+                JLog( LOG_LEVEL_WARN, true, "Unparseable line:%s\n", szLine );
             }
         }
     }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -86,13 +86,13 @@ JResult CGame::Init( const char *szBasedir )
     m_pAIMgr = new CAIMgr;
     m_pAIMgr->Init();
 
-    // Init the Dungeon
-    m_pDungeon = new CDungeon;
-    m_pDungeon->Init( szBasedir );
-
     // Init the Player
     m_pPlayer = new CPlayer;
     m_pPlayer->Init( szBasedir );
+
+    // Init the Dungeon
+    m_pDungeon = new CDungeon;
+    m_pDungeon->Init( szBasedir );
 
 #ifdef PROFILE
     ProfileInit();
@@ -112,7 +112,7 @@ JResult CGame::Init( const char *szBasedir )
 
 void CGame::Term()
 {
-    JLog( LOG_LEVEL_INFO, true, "Terminating the game..." );
+    JLog( LOG_LEVEL_WARN, true, "Terminating the game..." );
     if( m_pRender )
     {
         JLog( LOG_LEVEL_INFO, true, "Renderer..." );
@@ -262,7 +262,7 @@ void CGame::SetState( int eNewState )
         m_pCurState = reinterpret_cast<CStateBase *>( m_pRestState );
         break;
     default:
-        JLog( LOG_LEVEL_INFO, true, "Tried to change to unknown state.\n" );
+        JLog( LOG_LEVEL_ERROR, true, "Tried to change to unknown state.\n" );
         break;
     }
 }
@@ -408,7 +408,7 @@ bool CGame::Update( float fCurTime )
             GetPlayer()->DisplayEquipment( PLACEMENT_USE );
             break;
         default:
-            JLog( LOG_LEVEL_INFO, true, "Nothing to display for command\n" );
+            JLog( LOG_LEVEL_WARN, true, "Nothing to display for command\n" );
             break;
         }
         GetUse()->Update( fCurTime );
@@ -487,7 +487,7 @@ void CGame::HandleEvents( int &isActive, int &done )
             retval = m_pCurState->HandleKey( &event.key.keysym );
             if( retval == JBOGUSKEY )
             {
-                JLog( LOG_LEVEL_INFO, true, "Bogus command: 0x%x\n", event.key.keysym.sym );
+                JLog( LOG_LEVEL_ERROR, true, "Bogus command: 0x%x\n", event.key.keysym.sym );
                 GetMsgs()->Printf( "Unrecognized command: 0x%x\n", event.key.keysym.sym );
             }
             else if( retval == JQUITREQUEST )
@@ -515,7 +515,7 @@ void CGame::HandleEvents( int &isActive, int &done )
                 g_pGame->GetDungeon()->Zoom( -3 );
                 break;
             }
-            /*JLog( LOG_LEVEL_INFO, true, "Got up event type: %d which: %d button: %d state: %d at
+            /*JLog( LOG_LEVEL_DEBUG, true, "Got up event type: %d which: %d button: %d state: %d at
             <%d %d>\n", event.button.type, event.button.which, event.button.button,
             event.button.state, event.button.x, event.button.y );/* */
             break;

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -62,7 +62,7 @@ void CItem::SetCursed( int likelihood )
 JResult CItem::SpawnItem( JVector vSpawnPoint )
 {
     bool bItemSpawned = false;
-    JLog( LOG_LEVEL_INFO, false, "Trying to spawn item type: %s...", m_id->m_szName );
+    JLog( LOG_LEVEL_WARN, false, "Trying to spawn item type: %s...", m_id->m_szName );
 
     if( vSpawnPoint.IsInWorld() )
     {
@@ -72,7 +72,7 @@ JResult CItem::SpawnItem( JVector vSpawnPoint )
     JVector vTryPos;
     while( !bItemSpawned )
     {
-        JLog( LOG_LEVEL_INFO, false, "." );
+        JLog( LOG_LEVEL_WARN, false, "." );
         vTryPos.Init( (float)( Util::GetRandom( 0, DUNG_WIDTH - 1 ) ),
                       (float)( Util::GetRandom( 0, DUNG_HEIGHT - 1 ) ) );
 
@@ -96,7 +96,7 @@ JResult CItem::SpawnAt( JVector vSpawnPoint )
         m_vPos = vSpawnPoint;
         g_pGame->GetDungeon()->GetTile( m_vPos )->m_pCurItem = this;
 
-        JLog( LOG_LEVEL_INFO, false, "Success!\n" );
+        JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n", VEC_EXPAND( m_vPos ) );
         // g_pGame->GetMsgs()->Printf( "Success!\n" );
 
         return JSUCCESS;

--- a/src/JRect.h
+++ b/src/JRect.h
@@ -89,7 +89,7 @@ public:
         }
         if( left > right || top > bottom )
         {
-            JLog( LOG_LEVEL_INFO, true, "JRect has bad memory allocation: <%d %d, %d %d>\n", left,
+            JLog( LOG_LEVEL_ERROR, true, "JRect has bad memory allocation: <%d %d, %d %d>\n", left,
                   top, right, bottom );
             return false;
         }

--- a/src/ModState.cpp
+++ b/src/ModState.cpp
@@ -41,14 +41,14 @@ int CModState::OnHandleOpen( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "Open cmd still waiting for a directional key: Directional key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Direction(1 2 3 4 6 7 8 9):\n" );
         return 0;
     }
 
     // We got a directional key; do an "open" in that direction
-    JLog( LOG_LEVEL_INFO, true, "OPEN modifier got a directional\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "OPEN modifier got a directional\n" );
     if( TestOpen() )
     {
         if( DoOpen() )
@@ -86,14 +86,14 @@ int CModState::OnHandleClose( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "close cmd still waiting for a directional key: Directional key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Direction(1 2 3 4 6 7 8 9):\n" );
         return 0;
     }
 
     // We got a directional key; do an "open" in that direction
-    JLog( LOG_LEVEL_INFO, true, "CLOSE modifier got a directional\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "CLOSE modifier got a directional\n" );
     if( TestClose() )
     {
         if( DoClose() )
@@ -131,14 +131,14 @@ int CModState::OnHandleTunnel( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "Tunnel cmd still waiting for a directional key: Directional key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Direction(1 2 3 4 6 7 8 9):\n" );
         return 0;
     }
 
     // We got a directional key; do an "open" in that direction
-    JLog( LOG_LEVEL_INFO, true, "TUNNEL modifier got a directional\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "TUNNEL modifier got a directional\n" );
     if( TestTunnel() )
     {
         if( DoTunnel() )
@@ -186,13 +186,13 @@ int CModState::OnHandleInit( SDL_Keysym *keysym )
             }
             else
             {
-                JLog( LOG_LEVEL_INFO, true, "THROW not implemented yet.\n" );
+                JLog( LOG_LEVEL_WARN, true, "THROW not implemented yet.\n" );
                 ResetToState( STATE_COMMAND );
                 return 0;
             }
             break;
         default:
-            JLog( LOG_LEVEL_INFO, true,
+            JLog( LOG_LEVEL_ERROR, true,
                   "There seems to be some kind of mistake; I don't handle mod: %d\n", m_cCommand );
             ResetToState( STATE_COMMAND );
             return 0;
@@ -204,7 +204,7 @@ int CModState::OnHandleInit( SDL_Keysym *keysym )
         return 0;
     }
 
-    JLog( LOG_LEVEL_INFO, true,
+    JLog( LOG_LEVEL_ERROR, true,
           "Error: tried to init modify state when it was already initted...\n" );
     ResetToState( STATE_COMMAND );
     // shouldn't get here

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -88,7 +88,7 @@ JResult CMonster::InitAndSpawn( CMonsterDef *pmd, JVector vSpawnPoint )
 JResult CMonster::SpawnMonster( JVector vSpawnPoint )
 {
     bool bMonsterSpawned = false;
-    JLog( LOG_LEVEL_INFO, true, "Trying to spawn monster type: %s...", m_md->m_szName );
+    JLog( LOG_LEVEL_WARN, false, "Trying to spawn monster type: %s...", m_md->m_szName );
     if( vSpawnPoint.IsInWorld() )
     {
         return SpawnAt( vSpawnPoint );
@@ -97,7 +97,7 @@ JResult CMonster::SpawnMonster( JVector vSpawnPoint )
     JVector vTryPos;
     while( !bMonsterSpawned )
     {
-        JLog( LOG_LEVEL_INFO, false, "." );
+        JLog( LOG_LEVEL_WARN, false, "." );
         vTryPos.Init( (float)( Util::GetRandom( 0, DUNG_WIDTH - 1 ) ),
                       (float)( Util::GetRandom( 0, DUNG_HEIGHT - 1 ) ) );
 
@@ -116,7 +116,7 @@ JResult CMonster::SpawnAt( JVector vPos )
     {
         SetPos( vPos );
         g_pGame->GetDungeon()->GetTile( vPos )->m_pCurMonster = this;
-        JLog( LOG_LEVEL_INFO, false, "Success!\n" );
+        JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n", VEC_EXPAND( vPos ) );
         // g_pGame->GetMsgs()->Printf( "Success!\n" );
 
         return JSUCCESS;
@@ -128,7 +128,7 @@ float CMonster::Attack()
 {
     float fRoll = Util::Roll( "1d100" );
 
-    JLog( LOG_LEVEL_INFO, true, "%s rolled: %.2f\n", GetName(), fRoll );
+    JLog( LOG_LEVEL_WARN, true, "%s rolled: %.2f\n", GetName(), fRoll );
 
     return fRoll;
 }
@@ -139,7 +139,7 @@ float CMonster::Damage( float fDamageMult )
     float fDamageModifier = 0.0f;
 
     float fDamage = ( Util::Roll( szDamage ) + fDamageModifier ) * fDamageMult;
-    JLog( LOG_LEVEL_INFO, true, "%s did %.2f damage (damagemult: %.2f). ", GetName(), fDamage,
+    JLog( LOG_LEVEL_WARN, true, "%s did %.2f damage (damagemult: %.2f). ", GetName(), fDamage,
           fDamageMult );
 
     return fDamage;
@@ -162,7 +162,7 @@ int CMonster::TakeDamage( float fDamage )
         retval = STATUS_DEAD;
     }
 
-    JLog( LOG_LEVEL_INFO, true, "Remaining HP: %.2f \n", m_fCurHP );
+    JLog( LOG_LEVEL_WARN, true, "Remaining HP: %.2f \n", m_fCurHP );
 
     return retval;
 }

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -19,7 +19,7 @@ void CPlayer::Init( const char *szBasedir )
     m_TileSet = new DUNG_TILESET;
 
     // This will likely get moved somewhere else. --Jimbo
-    SpawnPlayer();
+    // SpawnPlayer();
 }
 
 bool CPlayer::Update( float fCurTime )
@@ -74,15 +74,16 @@ void CPlayer::PostDraw() { g_pGame->GetDungeon()->PostDraw(); }
 
 JResult CPlayer::SpawnPlayer()
 {
-    JLog( LOG_LEVEL_INFO, true, "Trying to spawn player..." );
+    JLog( LOG_LEVEL_WARN, false, "\nTrying to spawn player..." );
     JVector vTryPos;
     while( !m_bHasSpawned )
     {
+        JLog( LOG_LEVEL_WARN, false, "." );
         vTryPos.Init( (float)Util::GetRandom( 0, DUNG_WIDTH - 1 ),
                       (float)Util::GetRandom( 0, DUNG_HEIGHT - 1 ) );
 
-        JLog( LOG_LEVEL_DEBUG, true, "Trying to spawn player at <%.2f %.2f>...\n", vTryPos.x,
-              vTryPos.y );
+        // JLog( LOG_LEVEL_DEBUG, true, "Trying to spawn player at <%.2f %.2f>...\n", vTryPos.x,
+        //       vTryPos.y );
         // g_pGame->GetMsgs()->Printf( "Trying to spawn player at <%.2f %.2f>...\n", vTryPos.x,
         // vTryPos.y );
 
@@ -91,7 +92,8 @@ JResult CPlayer::SpawnPlayer()
         {
             m_vPos = vTryPos;
             m_bHasSpawned = true;
-            JLog( LOG_LEVEL_INFO, false, "Success!\n" );
+            JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n",
+                  VEC_EXPAND( m_vPos ) );
             // g_pGame->GetMsgs()->Printf( "Success!\n" );
         }
     }
@@ -136,7 +138,7 @@ void CPlayer::DisplayInventory( uint8 dwPlacement )
         pDT = g_pGame->GetUse();
         break;
     default:
-        JLog( LOG_LEVEL_INFO, true, "DisplayInventory got bad placement: %d\n", dwPlacement );
+        JLog( LOG_LEVEL_ERROR, true, "DisplayInventory got bad placement: %d\n", dwPlacement );
         return;
         break;
     }
@@ -160,7 +162,7 @@ void CPlayer::DisplayEquipment( uint8 dwPlacement )
         pDT = g_pGame->GetUse();
         break;
     default:
-        JLog( LOG_LEVEL_INFO, true, "DisplayEquipment got bad placement: %d\n", dwPlacement );
+        JLog( LOG_LEVEL_ERROR, true, "DisplayEquipment got bad placement: %d\n", dwPlacement );
         return;
         break;
     }
@@ -248,7 +250,7 @@ float CPlayer::Attack()
     float fRoll = Util::Roll( "1d100" );
     float fHitMod = g_pGame->GetPlayer()->m_fToHitModifier;
 
-    JLog( LOG_LEVEL_INFO, true, "You rolled: %.2f, +to-hit Bonus: %.2f = Total: %.2f\n", fRoll,
+    JLog( LOG_LEVEL_WARN, true, "You rolled: %.2f, +to-hit Bonus: %.2f = Total: %.2f\n", fRoll,
           fHitMod, fRoll + fHitMod );
 
     fRoll += fHitMod;
@@ -259,7 +261,7 @@ float CPlayer::Attack()
 float CPlayer::Damage( float fDamageMult )
 {
     float fDamage = ( Util::Roll( m_szDamage ) + m_fDamageModifier ) * fDamageMult;
-    JLog( LOG_LEVEL_INFO, true, "You did %.2f damage (damagemult: %.2f). ", fDamage, fDamageMult );
+    JLog( LOG_LEVEL_WARN, true, "You did %.2f damage (damagemult: %.2f). ", fDamage, fDamageMult );
 
     return fDamage;
 }
@@ -306,13 +308,13 @@ int CPlayer::TakeDamage( float fDamage, char *szMon )
         memset( m_szKilledBy, 0, strlen( szMon ) + 1 );
         strcpy( m_szKilledBy, szMon );
         // This is the end of the game; make the game end on next update.
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "%s died on dungeon level %d, while level %d, killed by a %s.\n", m_szName,
               g_pGame->GetDungeon()->depth, (int)m_fLevel, m_szKilledBy );
         g_pGame->SetState( STATE_ENDGAME );
     }
 
-    JLog( LOG_LEVEL_INFO, true, "Remaining HP: %.2f \n", m_fCurHitPoints );
+    JLog( LOG_LEVEL_WARN, true, "Remaining HP: %.2f \n", m_fCurHitPoints );
 
     return retval;
 }

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -255,7 +255,7 @@ void CRender::PreDrawObjects( JRect rcBounds, uint32 Texture, bool bTranslate, b
     glBindTexture( GL_TEXTURE_2D, Texture );
     if( !glIsTexture( Texture ) )
     {
-        JLog( LOG_LEVEL_INFO, true, "Hey! That's not a texture.\n" );
+        JLog( LOG_LEVEL_ERROR, true, "Hey! That's not a texture.\n" );
     }
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT );
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT );

--- a/src/RestState.cpp
+++ b/src/RestState.cpp
@@ -53,12 +53,12 @@ int CRestState::OnHandleTick( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "REST state still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_WARN, true, "REST state still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_INFO, true, "TICK modifier got a valid key\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "TICK modifier got a valid key\n" );
     DoTick();
 
     return 0;

--- a/src/StringInputState.cpp
+++ b/src/StringInputState.cpp
@@ -59,13 +59,13 @@ int CStringInputState::OnHandleName( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "Name cmd still waiting for a Alphanumeric key.\n" );
+        JLog( LOG_LEVEL_WARN, true, "Name cmd still waiting for a Alphanumeric key.\n" );
         //        g_pGame->GetMsgs()->Printf("Direction(1 2 3 4 6 7 8 9):\n");
         return 0;
     }
 
     // We got a alpha key; append it to the name
-    JLog( LOG_LEVEL_INFO, true, "NAME modifier got a alpha\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "NAME modifier got a alpha\n" );
     g_pGame->GetMsgs()->Clear();
     g_pGame->GetMsgs()->Printf( "Character Name: %s", m_szInput );
 
@@ -85,13 +85,13 @@ int CStringInputState::OnHandleHaggle( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "HAGGLE cmd still waiting for a Numeric key.\n" );
+        JLog( LOG_LEVEL_WARN, true, "HAGGLE cmd still waiting for a Numeric key.\n" );
         g_pGame->GetMsgs()->Printf( "Enter a number.\n" );
         return 0;
     }
 
     // We got a numeric key; add to haggle number
-    JLog( LOG_LEVEL_INFO, true, "HAGGLE modifier got a numeric\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "HAGGLE modifier got a numeric\n" );
     if( TestHaggle() )
     {
         if( DoHaggle() )
@@ -139,7 +139,7 @@ int CStringInputState::OnHandleInit( SDL_Keysym *keysym )
             mod = SI_HAGGLE;
             break;
         default:
-            JLog( LOG_LEVEL_INFO, true,
+            JLog( LOG_LEVEL_ERROR, true,
                   "There seems to be some kind of mistake; I don't handle mod: %d\n", m_cCommand );
             ResetToState( STATE_COMMAND );
             return 0;
@@ -151,7 +151,7 @@ int CStringInputState::OnHandleInit( SDL_Keysym *keysym )
         return 0;
     }
 
-    JLog( LOG_LEVEL_INFO, true,
+    JLog( LOG_LEVEL_ERROR, true,
           "Error: tried to init stringinput state when it was already initted...\n" );
     ResetToState( STATE_COMMAND );
     // shouldn't get here

--- a/src/Tileset.cpp
+++ b/src/Tileset.cpp
@@ -38,7 +38,7 @@ JResult CTileset::Load( const char *szName, int dwCellWidth, int dwCellHeight )
     }
     else
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "g_pGame not initialized yet, when loading %s -- m_Texture not created.\n", szName );
     }
 #endif

--- a/src/UseState.cpp
+++ b/src/UseState.cpp
@@ -42,14 +42,14 @@ int CUseState::OnHandleWield( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "Use cmd still waiting for a alphabetic key: Alpha key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Choose an item from inventory(a to z):\n" );
         return 0;
     }
 
     // We got a alpha key; do a "wield" of that item
-    JLog( LOG_LEVEL_INFO, true, "WIELD got a selection\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "WIELD got a selection\n" );
     if( TestWield() )
     {
         if( DoWield() )
@@ -89,14 +89,14 @@ int CUseState::OnHandleRemove( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "Use cmd still waiting for a alphabetic key: Alpha key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Choose an item from equipment(a to z):\n" );
         return 0;
     }
 
     // We got a alpha key; do a "remove" of that item
-    JLog( LOG_LEVEL_INFO, true, "REMOVE  got a selection\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "REMOVE  got a selection\n" );
     if( TestRemove() )
     {
         if( DoRemove() )
@@ -135,14 +135,14 @@ int CUseState::OnHandleDrop( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "Use cmd still waiting for a alphabetic key: Alpha key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Choose an item from inventory(a to z):\n" );
         return 0;
     }
 
     // We got a alpha key; do a "drop" of that item
-    JLog( LOG_LEVEL_INFO, true, "DROP  got a selection\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "DROP  got a selection\n" );
     if( TestDrop() )
     {
         if( DoDrop() )
@@ -182,14 +182,14 @@ int CUseState::OnHandleQuaff( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_WARN, true,
               "Use cmd still waiting for a alphabetic key: Alpha key not pressed.\n" );
         g_pGame->GetMsgs()->Printf( "Choose an item from inventory(a to z):\n" );
         return 0;
     }
 
     // We got a alpha key; do a "quaff" of that item
-    JLog( LOG_LEVEL_INFO, true, "QUAFF  got a selection\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "QUAFF  got a selection\n" );
     if( TestQuaff() )
     {
         if( DoQuaff() )
@@ -242,7 +242,7 @@ int CUseState::OnHandleInit( SDL_Keysym *keysym )
             g_pGame->GetMsgs()->Printf( "Quaff which item? [a-z]\n" );
             break;
         default:
-            JLog( LOG_LEVEL_INFO, true,
+            JLog( LOG_LEVEL_ERROR, true,
                   "There seems to be some kind of mistake; I don't handle mod: %d\n", m_cCommand );
             ResetToState( STATE_COMMAND );
             return 0;
@@ -254,7 +254,8 @@ int CUseState::OnHandleInit( SDL_Keysym *keysym )
         return 0;
     }
 
-    JLog( LOG_LEVEL_INFO, true, "Error: tried to init USE state when it was already initted...\n" );
+    JLog( LOG_LEVEL_ERROR, true,
+          "Error: tried to init USE state when it was already initted...\n" );
     ResetToState( STATE_COMMAND );
     // shouldn't get here
     return JRESETSTATE;
@@ -313,7 +314,7 @@ CLink<CItem> *CUseState::GetResponse( eUseModifier whichUse )
         pList = g_pGame->GetPlayer()->m_llInventory;
         break;
     default:
-        JLog( LOG_LEVEL_INFO, true, "Can't get response for : %d\n", whichUse );
+        JLog( LOG_LEVEL_ERROR, true, "Can't get response for : %d\n", whichUse );
         return NULL;
         break;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main( int argc, char **argv )
     result = g_pGame->Init( "../JMoria/" );
     if( result != JSUCCESS )
     {
-        JLog( LOG_LEVEL_INFO, true, "Error in game initialization. Terminating.\n" );
+        JLog( LOG_LEVEL_ERROR, true, "Error in game initialization. Terminating.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
fixed all log outputs so that they make sense with LOG_LEVEL_WARN set

DEBUG = noise needed while debugging
INFO = good developer info, overkill for gameplay
WARN = output tailored to being interesting to players (also actual warnings about missed keypresses)
ERROR = actual errors (bad file, can't render, &c)

if you want the player to see it on stdout (play game to get an idea of what that looks like), set LOG_LEVEL_WARN. For dev stuff, LOG_LEVEL_INFO. For problems, LOG_LEVEL_ERROR. To make it "go away and shut up", LOG_LEVEL_DEBUG