### PR TITLE
chore: unbreak tests

### DIFF
--- a/Resources/Items.txt
+++ b/Resources/Items.txt
@@ -243,7 +243,29 @@ Weight        4.0
 Speed         7.0
 Color        <200,200,200,255>
 }
+Item <Scroll of Remove Curse>
+{
+Plural      <Scrolls of Remove Curse>
+Type        <ITEM_IDX_SCROLL>
+Effect      <EFFECT_TYPE_INTRINSIC>,<EFFECT_TYPE_LOSE>
+Value       10.0
+Level       1
+Weight      2.0
+Color       <225,225,50,255>
+}
 
+Item <Potion of Minor Healing>
+{
+    Plural        <Potions of Minor Healing>
+    Type        <ITEM_IDX_POTION>
+    Effect      <EFFECT_TYPE_HEAL>,<EFFECT_FLAG_HP>,<1d20>
+    Effect      <EFFECT_TYPE_HEAL>,<EFFECT_FLAG_POISON>
+    Effect      <EFFECT_TYPE_HEAL>,<EFFECT_FLAG_BLIND>
+    Value       1000.0
+    Level       2
+    Weight      0.2
+    Color        <225,50,225,255>
+}
 Item <Long Sword>
 {
     Plural        <Long swords>
@@ -310,6 +332,26 @@ Level       20
 Weight      0.2
 Color        <225,225,50,255>
 }
+Item <Ring of Fire Resistance>
+{
+Plural        <Rings of Fire Resistance>
+Type        <ITEM_IDX_RING>
+Value       300.0
+Level       10
+Effect      <EFFECT_TYPE_INTRINSIC>,<EFFECT_FLAG_FIRE>,<EFFECT_MOD_RESIST>
+Weight      0.2
+Color        <225,225,50,255>
+}
+Item <Ring of Protection>
+{
+    Plural        <Rings of Protection>
+    Type        <ITEM_IDX_RING>
+    ACBonus     <1d20>
+    Value       1000.0
+    Level       20
+    Weight      0.2
+    Color        <225,50,225,255>
+}
 Item <Torch>
 {
 Plural        <Torches>
@@ -330,16 +372,6 @@ Flags       <ITEM_FLAG_NEEDSAMMO>
 Level       5
 Weight      2.0
 Color        <225,225,50,255>
-}
-Item <Scroll of Remove Curse>
-{
-Plural      <Scrolls of Remove Curse>
-Type        <ITEM_IDX_SCROLL>
-Effect      <EFFECT_TYPE_INTRINSIC>,<EFFECT_TYPE_LOSE>
-Value       10.0
-Level       1
-Weight      2.0
-Color       <225,225,50,255>
 }
 Item <Flask of Oil>
 {
@@ -461,16 +493,6 @@ AC          4.0
 Weight      2.0
 Color        <225,225,50,255>
 }
-Item <Ring of Fire Resistance>
-{
-Plural        <Rings of Fire Resistance>
-Type        <ITEM_IDX_RING>
-Value       300.0
-Level       10
-Effect      <EFFECT_TYPE_INTRINSIC>,<EFFECT_FLAG_FIRE>,<EFFECT_MOD_RESIST>
-Weight      0.2
-Color        <225,225,50,255>
-}
 Item <Cloak>
 {
 Plural        <Cloaks>
@@ -509,31 +531,6 @@ Level       1
 Weight      2.0
 Color        <225,225,50,255>
 }
-
-Item <Ring of Protection>
-{
-    Plural        <Rings of Protection>
-    Type        <ITEM_IDX_RING>
-    ACBonus     <1d20>
-    Value       1000.0
-    Level       20
-    Weight      0.2
-    Color        <225,50,225,255>
-}
-
-Item <Potion of Minor Healing>
-{
-    Plural        <Potions of Minor Healing>
-    Type        <ITEM_IDX_POTION>
-    Effect      <EFFECT_TYPE_HEAL>,<EFFECT_FLAG_HP>,<1d20>
-    Effect      <EFFECT_TYPE_HEAL>,<EFFECT_FLAG_POISON>
-    Effect      <EFFECT_TYPE_HEAL>,<EFFECT_FLAG_BLIND>
-    Value       1000.0
-    Level       2
-    Weight      0.2
-    Color        <225,50,225,255>
-}
-
 Item <Small Steel Shield>
 {
     Plural        <Small Steel Shields>
@@ -545,7 +542,6 @@ Item <Small Steel Shield>
     Weight       10.0
     Color        <115,112,121,255>
 }
-
 Item <Large Steel Shield>
 {
     Plural        <Large Steel Shields>
@@ -558,6 +554,7 @@ Item <Large Steel Shield>
     Color        <115,112,121,255>
 }
 Item <Steel Shield>
+{
     Plural      <Steel Shields>
     Type        <ITEM_IDX_SHIELD>
     Value        125.0

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -68,6 +68,7 @@ JResult CMonster::CreateMonster( CMonsterDef *pmd, JVector vSpawnPoint, bool bNe
             // That spawn failed; clean up
             // delete pMon;
             // pMon = NULL;
+            return retval;
         }
     }
 

--- a/test/features/game.feature
+++ b/test/features/game.feature
@@ -21,22 +21,22 @@ Feature: Game
         And I initialize the game
         When I terminate the game
         Then the game terminates successfully
-    @skip
+    # @skip
     Scenario: Player Seek works
         Given I have a game
         And I initialize the game
         And the game has a player
-        And I spawn a monster with SEEK
-        And I update the monster's brain pizza
+        And I spawn a Red Dragon:12, a monster with SEEK
+        And I update the monster's brain
         Then the game initalized successfully
-        And the monster spawned successfully
-        And the monster wants to move toward the player
-    @skip
+        And the Red Dragon spawned successfully
+        And the Red Dragon wants to move toward the player
+    # @skip
     Scenario: AI state changes work
         Given I have a game
         And I initialize the game
         And the game has a player
-        And I spawn a monster with SEEK
-        And I update the monster's brain pizza
+        And I spawn a Red Dragon:12, a monster with SEEK
+        And I update the monster's brain
         When I update the monster's brain again
-        And the monster moves toward the player
+        And the Red Dragon moves toward the player

--- a/test/features/step_definitions/EquipmentSteps.cpp
+++ b/test/features/step_definitions/EquipmentSteps.cpp
@@ -31,6 +31,13 @@ GIVEN( "^I spawn a ([A-Za-z ]+):([0-9]+)$" )
     context->index = index;
 
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( context->index );
+
+    int compare = strcmp( context->szBuffer, pid->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
     context->result = CItem::CreateItem( pid, context->vec_b );
 }
 
@@ -40,6 +47,13 @@ GIVEN( "^the player has a ([A-Za-z ]+):([0-9]+) in inventory$" )
     REGEX_PARAM( std::string, item );
     REGEX_PARAM( int, item_id );
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
+    int compare = strcmp( item.c_str(), pid->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
+
     g_pGame->GetPlayer()->PickUp( context->vec_b );
     int inv_index =
         g_pGame->GetPlayer()->m_llInventory->GetLink( pid->m_dwIndex )->m_lpData->m_id->m_dwIndex;
@@ -56,6 +70,12 @@ GIVEN( "^the ([A-Za-z ]+):([0-9]+) (is|is not) cursed$" )
     REGEX_PARAM( std::string, choice );
     int chance = ( choice == "is" ) ? 100 : 0;
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
+    int compare = strcmp( item.c_str(), pid->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
     CDungeonTile *pTile = g_pGame->GetDungeon()->GetTile( context->vec_b );
     CItem *pItem = pTile->m_pCurItem;
     pItem->SetCursed( chance );
@@ -74,6 +94,12 @@ GIVEN( "^the player has a ([A-Za-z ]+):([0-9]+) in equipment at ([-0-9]+)$" )
     REGEX_PARAM( int, item_id );
     REGEX_PARAM( int, equip_id );
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
+    int compare = strcmp( item.c_str(), pid->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
     CItem *expected = NULL;
     CItem *actual = g_pGame->GetPlayer()->m_llEquipment->GetLink( equip_id )->m_lpData;
     EXPECT_NE( expected, actual );
@@ -126,7 +152,15 @@ THEN( "^The ([A-Za-z ]+):([0-9]+) is in (inventory|equipment) at ([-0-9]+)$" )
                                                       : g_pGame->GetPlayer()->m_llEquipment;
     CItem *expected = NULL;
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
-    int index = ( list == "inventory" ) ? pid->m_dwIndex : equip_id;
+    int compare = strcmp( item.c_str(), pid->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
+    int item_type = pid->m_dwIndex;
+    int equip_slot = EQUIP_IDX_MAIN_HAND + equip_id;
+    int index = ( list == "inventory" ) ? item_type : equip_slot;
     CLink<CItem> *pLink = pList->GetLink( index );
     CItem *actual = pLink->m_lpData;
     EXPECT_NE( expected, actual );
@@ -136,7 +170,7 @@ THEN( "^The ([A-Za-z ]+):([0-9]+) is in (inventory|equipment) at ([-0-9]+)$" )
 
     int result = strcmp( want, have );
     if( result != 0 )
-        JLog( LOG_LEVEL_WARN, true, "want %s have %s\n", want, have );
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", want, have );
 
     EXPECT_EQ( result, 0 );
 }
@@ -152,6 +186,12 @@ THEN( "^The ([A-Za-z ]+):([0-9]+) is not in (inventory|equipment) at ([-0-9]+)$"
                                                       : g_pGame->GetPlayer()->m_llEquipment;
     CItem *expected = NULL;
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
+    int compare = strcmp( item.c_str(), pid->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
     int index = ( list == "inventory" ) ? pid->m_dwIndex : equip_id;
     CLink<CItem> *pLink = pList->GetLink( index );
     CItem *actual = NULL;

--- a/test/features/step_definitions/GameSteps.cpp
+++ b/test/features/step_definitions/GameSteps.cpp
@@ -31,31 +31,51 @@ GIVEN( "^the game has a player$" )
     int actual = context->result;
     EXPECT_EQ( actual, JSUCCESS );
 }
-GIVEN( "^I spawn a monster with SEEK$" )
+GIVEN( "^I spawn a ([-A-Za-z ]+):([0-9]+), a monster with SEEK$" )
 {
+    REGEX_PARAM(std::string, monster);
+    REGEX_PARAM(int, monster_id);
     ScenarioScope<TestCtx> context;
-    context->vec_b.Init( -2, 2 );
+    context->vec_b.Init( -2, -2 );
     context->vec_b += context->vec;
 
-    int seek_monster = 12;
-    CMonsterDef *pmd = g_pGame->GetDungeon()->GetMonsterDef( seek_monster );
+    // Dungeon mangling for test: make sure LZ is clear
+    JVector vLZ(context->vec_b.x, context->vec_b.y);
+    for( int y = 0; y < 2; y++ )
+    {
+        vLZ.y = context->vec_b.y+y;
+        for( int x = 0; x < 2; x++ )
+        {
+            vLZ.x = context->vec_b.x+x;
+            CDungeonTile *pLZ = g_pGame->GetDungeon()->GetTile(vLZ);
+            pLZ->m_dtd->m_dwType = DUNG_IDX_FLOOR;
+        }
+    }
+
+    int expected = DUNG_COLL_NO_COLLISION;
+    int actual = g_pGame->GetDungeon()->IsWalkableFor(context->vec_b);
+
+    EXPECT_EQ(expected, actual);
+    // End Dungeon Mangling
+
+    CMonsterDef *pmd = g_pGame->GetDungeon()->GetMonsterDef( monster_id );
+
+    // Monster is correct monster
+    int compare = strcmp(monster.c_str(), pmd->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pmd->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
 
     context->result = CMonster::CreateMonster( pmd, context->vec_b );
 
-    printf( "<%f %f> %s %d\n", VEC_EXPAND( context->vec_b ), pmd->m_szName, context->result );
+    JLog( LOG_LEVEL_ERROR, true, "<%f %f> %s %d\n", VEC_EXPAND( context->vec_b ), pmd->m_szName, context->result );
 }
-GIVEN( "^I update the monster's brain pizza$" )
+GIVEN( "^I update the monster's brain$" )
 {
     ScenarioScope<TestCtx> context;
-    CDungeon *pDungeon = g_pGame->GetDungeon();
-    printf( "dung %d ", pDungeon->m_dwHeight );
-
-    CDungeonTile *pTile = pDungeon->GetTile( context->vec_b );
-    printf( "tile %d ", pTile->m_dwFlags );
-
-    CMonster *pMon = pTile->m_pCurMonster;
-
-    printf( "mon %f\n", pMon->m_fHP );
+    CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
     pMon->m_pBrain->Update( 1.0f );
 }
 
@@ -67,19 +87,8 @@ GIVEN( "^I update the monster's brain pizza$" )
 WHEN( "^I update the monster's brain again$" )
 {
     ScenarioScope<TestCtx> context;
-    CDungeon *pDungeon = g_pGame->GetDungeon();
-    printf( "dung %d ", pDungeon->m_dwHeight );
-
-    CDungeonTile *pTile = pDungeon->GetTile( context->vec_b );
-    printf( "tile %d ", pTile->m_dwFlags );
-
-    CMonster *pMon = pTile->m_pCurMonster;
-
-    printf( "mon %f\n", pMon->m_fHP );
+    CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
     pMon->m_pBrain->Update( 1.0f );
-    // pMon = pTile->m_pCurMonster;
-
-    // printf("mon_after %f\n", pMon->m_fHP);
 }
 WHEN( "^I terminate the game$" ) { g_pGame->Term(); }
 
@@ -98,26 +107,40 @@ THEN( "^the game initalized successfully$" )
 
 THEN( "^the game terminates successfully$" ) { EXPECT_EQ( true, true ); }
 
-THEN( "^the monster spawned successfully$" )
+THEN( "^the ([-A-Za-z ]+) spawned successfully$" )
 {
+    REGEX_PARAM(std::string, monster);
     ScenarioScope<TestCtx> context;
     int actual = context->result;
     EXPECT_EQ( actual, JSUCCESS );
-    CDungeon *pDungeon = g_pGame->GetDungeon();
-    CDungeonTile *pTile = pDungeon->GetTile( context->vec_b );
-    CMonster *pMon = pTile->m_pCurMonster;
-    char monster[32];
-    char *expected = "Red Dragon";
-    sprintf( monster, "%s", pMon->m_md->m_szName );
+    CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
 
-    EXPECT_EQ( strcmp( monster, expected ), 0 );
+    // Monster is correct monster
+    int compare = strcmp(monster.c_str(), pMon->m_md->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
 }
 
-THEN( "^the monster wants to move toward the player$" )
+THEN( "^the ([-A-Za-z ]+) wants to move toward the player$" )
 {
-    JVector expected( 1, -1 );
+    REGEX_PARAM(std::string, monster);
     ScenarioScope<TestCtx> context;
     CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
+
+    // Monster is correct monster
+    int compare = strcmp(monster.c_str(), pMon->m_md->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
+
+    // Monster wants to move toward player
+    JLog(LOG_LEVEL_ERROR, false, "heading <%.2f %.2f>\n", VEC_EXPAND(pMon->m_pBrain->m_vVel));
+    JVector expected( 1.0f, 1.0f );
     JVector actual = pMon->m_pBrain->m_vVel;
     EXPECT_EQ( expected.x, actual.x );
     EXPECT_EQ( expected.y, actual.y );
@@ -125,9 +148,9 @@ THEN( "^the monster wants to move toward the player$" )
     EXPECT_EQ( pMon->m_pBrain->GetState(), BRAINSTATE_GOTODEST );
 }
 
-THEN( "^the monster moves toward the player$" )
+THEN( "^the ([-A-Za-z ]+) moves toward the player$" )
 {
-    JVector delta( 1, -1 );
+    REGEX_PARAM(std::string, monster);
     ScenarioScope<TestCtx> context;
     // Monster not in old pos
     CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
@@ -136,15 +159,17 @@ THEN( "^the monster moves toward the player$" )
     EXPECT_EQ( expected, true );
 
     // Monster is in new pos
+    JVector delta( 1, 1 );
     context->vec_b += delta;
     pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
     expected = pMon != NULL;
     EXPECT_EQ( expected, true );
 
     // Monster is correct monster
-    char monster[32];
-    char *wanted = "Red Dragon";
-    sprintf( monster, "%s", pMon->m_md->m_szName );
-
-    EXPECT_EQ( strcmp( monster, wanted ), 0 );
+    int compare = strcmp(monster.c_str(), pMon->m_md->m_szName);
+    if( compare != 0 )
+    {
+        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName);
+    }
+    EXPECT_EQ(compare, 0);
 }

--- a/test/features/step_definitions/TestContext.hpp
+++ b/test/features/step_definitions/TestContext.hpp
@@ -17,7 +17,7 @@
 
 // main game pointer
 CGame *g_pGame = NULL;
-eLogLevel g_eLogLevel = LOG_LEVEL_ERROR;
+eLogLevel g_eLogLevel = LOG_LEVEL_WARN;
 
 /*#######
 ##

--- a/test/features/step_definitions/TestContext.hpp
+++ b/test/features/step_definitions/TestContext.hpp
@@ -17,7 +17,7 @@
 
 // main game pointer
 CGame *g_pGame = NULL;
-eLogLevel g_eLogLevel = LOG_LEVEL_WARN;
+eLogLevel g_eLogLevel = LOG_LEVEL_ERROR;
 
 /*#######
 ##


### PR DESCRIPTION
Equipment tests were broken because tests are dependent upon indices in Items.txt, and those indices were changed. This is fixed, by resetting the indices in the file so as not to disrupt the tests. Also put in hardening in the tests to catch this (easy to make) error in the future.

AI tests were broken because the RNG sometimes makes it difficult to land a player and a monster nearby consistently. This is fixed, by mangling the dungeon to force open ground between the player and the monster spawn point. 

All tests are turned on, no `@skip` at the moment. If tests break in the future, can use @skip until they are fixed again.