### PR TITLE
chore: refactor log levels

### DIFF
--- a/src/AIMgr.cpp
+++ b/src/AIMgr.cpp
@@ -27,10 +27,7 @@ bool CAIMgr::Update( float fCurTime )
     return true;
 }
 
-void CAIMgr::DestroyBrain( CAIBrain *delete_me )
- { 
-    m_llAIBrains->Remove( delete_me->m_pllLink );
- }
+void CAIMgr::DestroyBrain( CAIBrain *delete_me ) { m_llAIBrains->Remove( delete_me->m_pllLink ); }
 
 CAIBrain::CAIBrain() : m_dwMoveType( 0 ), m_fSpeed( 0.0f ), m_eBrainState( BRAINSTATE_INVALID ) {}
 
@@ -38,7 +35,7 @@ bool CAIBrain::Update( float fCurTime )
 {
     if( m_vPos.IsZero() )
     {
-        JLog(LOG_LEVEL_INFO, true, "%s has a bad position...\n", m_pParent->m_md->m_szName);
+        JLog( LOG_LEVEL_DEBUG, true, "%s has a bad position...\n", m_pParent->m_md->m_szName );
         // g_pGame->GetDungeon()->RemoveMonster( m_pParent);
 
         return false;
@@ -61,11 +58,11 @@ bool CAIBrain::Update( float fCurTime )
         return UpdateRest( fCurTime );
         break;
     case BRAINSTATE_GOTODEST:
-        JLog( LOG_LEVEL_DEBUG, true, "I'm going, I'm going\n" );
+        JLog( LOG_LEVEL_NOISE, true, "I'm going, I'm going\n" );
         return UpdateGoToDest( fCurTime );
         break;
     case BRAINSTATE_SEEK:
-        JLog( LOG_LEVEL_DEBUG, true, "I seek\n" );
+        JLog( LOG_LEVEL_NOISE, true, "I seek\n" );
         return UpdateSeek( fCurTime );
         break;
     case BRAINSTATE_IDLE:
@@ -85,13 +82,13 @@ bool CAIBrain::UpdateSeek( float fCurTime )
     {
     case MON_AI_100RANDOMMOVE:
     {
-        JLog( LOG_LEVEL_DEBUG, true, "rng\n" );
+        JLog( LOG_LEVEL_NOISE, true, "rng\n" );
         SetRandomDest( fCurTime );
     }
     break;
     case MON_AI_75RANDOMMOVE:
     {
-        JLog( LOG_LEVEL_DEBUG, true, "chaos monkey\n" );
+        JLog( LOG_LEVEL_NOISE, true, "chaos monkey\n" );
         if( Util::Roll( "1d100" ) <= 75 )
         {
             SetRandomDest( fCurTime );
@@ -105,18 +102,18 @@ bool CAIBrain::UpdateSeek( float fCurTime )
     case MON_AI_DONTMOVE:
     {
 
-        JLog( LOG_LEVEL_DEBUG, true, "i no move\n" );
+        JLog( LOG_LEVEL_NOISE, true, "i no move\n" );
         SetRandomDest( fCurTime );
     }
     break;
     case MON_AI_SEEKPLAYER:
     {
-        JLog( LOG_LEVEL_DEBUG, true, "seek player\n" );
+        JLog( LOG_LEVEL_NOISE, true, "seek player\n" );
         WalkSeek( fCurTime );
     }
     break;
     default:
-        JLog( LOG_LEVEL_DEBUG, true, "bad seek\n" );
+        JLog( LOG_LEVEL_NOISE, true, "bad seek\n" );
         return false;
     }
 
@@ -135,16 +132,18 @@ bool CAIBrain::UpdateGoToDest( float fCurTime )
     {
         m_fStateTicks -= 1.0f;
         didWalk = true;
-        if( m_vVel.IsZero() ) continue;
+        if( m_vVel.IsZero() )
+            continue;
         JVector vTryPos( m_vPos + m_vVel );
-        JLog( LOG_LEVEL_DEBUG, true, "and we're walking... <%.2f %.2f> + <%.2f %.2f> = <%.2f %.2f> ",
-        VEC_EXPAND(m_vPos), VEC_EXPAND(m_vVel), VEC_EXPAND(vTryPos) );
+        JLog( LOG_LEVEL_NOISE, true,
+              "and we're walking... <%.2f %.2f> + <%.2f %.2f> = <%.2f %.2f> ", VEC_EXPAND( m_vPos ),
+              VEC_EXPAND( m_vVel ), VEC_EXPAND( vTryPos ) );
         if( !Util::IsInWorld( vTryPos ) )
         {
             continue;
         }
 
-        JLog( LOG_LEVEL_DEBUG, true, "and we're in the world... " );
+        JLog( LOG_LEVEL_NOISE, true, "and we're in the world... " );
         int dwCollideType = g_pGame->GetDungeon()->IsWalkableFor( vTryPos );
         switch( dwCollideType )
         {
@@ -155,15 +154,15 @@ bool CAIBrain::UpdateGoToDest( float fCurTime )
             CollideWithPlayer();
             break;
         default:
-            JLog(LOG_LEVEL_DEBUG, true, "you hit %d ", dwCollideType);
+            JLog( LOG_LEVEL_NOISE, true, "you hit %d ", dwCollideType );
             break;
         }
     }
 
-    JLog(LOG_LEVEL_DEBUG, false, "\n");
+    JLog( LOG_LEVEL_NOISE, false, "\n" );
     if( didWalk )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "looking\n" );
+        JLog( LOG_LEVEL_NOISE, true, "looking\n" );
         SetState( BRAINSTATE_SEEK );
     }
 
@@ -172,10 +171,10 @@ bool CAIBrain::UpdateGoToDest( float fCurTime )
 
 void CAIBrain::Move()
 {
-    JLog( LOG_LEVEL_DEBUG, true, "swing and a miss " );
+    JLog( LOG_LEVEL_NOISE, true, "swing and a miss " );
     if( m_dwMoveType != MON_AI_DONTMOVE )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "on the move " );
+        JLog( LOG_LEVEL_NOISE, true, "on the move " );
         g_pGame->GetDungeon()->GetTile( m_vPos )->m_pCurMonster = NULL;
         m_vPos += m_vVel;
         g_pGame->GetDungeon()->GetTile( m_vPos )->m_pCurMonster = m_pParent;
@@ -184,7 +183,7 @@ void CAIBrain::Move()
 
 void CAIBrain::CollideWithPlayer()
 {
-    JLog( LOG_LEVEL_DEBUG, true, "ouch! you ran into the player! " );
+    JLog( LOG_LEVEL_NOISE, true, "ouch! you ran into the player! " );
     char szStatus[16];
     float fDamageMult = 1.0f;
     // TODO: make this use all the attacks, not just the first one
@@ -221,9 +220,9 @@ bool CAIBrain::SetRandomDest( float fCurTime )
     JFVector delta, dest;
     delta.Init( (int)( Util::GetRandom( -2.0f, 2.0f ) ), (int)( Util::GetRandom( -2.0f, 2.0f ) ) );
     dest = m_vPos + delta;
-    
-    JLog( LOG_LEVEL_DEBUG, true, "and we're rnging... <%.2f %.2f> + <%.2f %.2f> = <%.2f %.2f> ",
-        VEC_EXPAND(m_vPos), VEC_EXPAND(delta), VEC_EXPAND(dest) );
+
+    JLog( LOG_LEVEL_NOISE, true, "and we're rnging... <%.2f %.2f> + <%.2f %.2f> = <%.2f %.2f> ",
+          VEC_EXPAND( m_vPos ), VEC_EXPAND( delta ), VEC_EXPAND( dest ) );
 
     if( Util::IsInWorld( dest ) )
     {
@@ -233,10 +232,12 @@ bool CAIBrain::SetRandomDest( float fCurTime )
         case DUNG_COLL_NO_COLLISION:
         case DUNG_COLL_PLAYER:
             m_vVel = delta;
-            JLog( LOG_LEVEL_DEBUG, true, "hit %d change course <%.2f %.2f>\n", dwCollideType, VEC_EXPAND(m_vVel));
+            JLog( LOG_LEVEL_NOISE, true, "hit %d change course <%.2f %.2f>\n", dwCollideType,
+                  VEC_EXPAND( m_vVel ) );
             break;
         default:
-            JLog( LOG_LEVEL_DEBUG, true, "hit %d steady course <%.2f %.2f>\n",dwCollideType, VEC_EXPAND(m_vVel));
+            JLog( LOG_LEVEL_NOISE, true, "hit %d steady course <%.2f %.2f>\n", dwCollideType,
+                  VEC_EXPAND( m_vVel ) );
             // m_vVel.Init();
             break;
         }
@@ -266,8 +267,8 @@ bool CAIBrain::WalkSeek( float fCurTime )
 
     dest = m_vPos + delta;
 
-        JLog( LOG_LEVEL_DEBUG, true, "and we're seeking... <%.2f %.2f> + <%.2f %.2f> = <%.2f %.2f> ",
-        VEC_EXPAND(m_vPos), VEC_EXPAND(delta), VEC_EXPAND(dest) );
+    JLog( LOG_LEVEL_NOISE, true, "and we're seeking... <%.2f %.2f> + <%.2f %.2f> = <%.2f %.2f> ",
+          VEC_EXPAND( m_vPos ), VEC_EXPAND( delta ), VEC_EXPAND( dest ) );
     int dwCollideType = DUNG_COLL_NO_COLLISION;
     if( dest.IsInWorld() )
     {
@@ -288,10 +289,12 @@ bool CAIBrain::WalkSeek( float fCurTime, JVector &delta, int dwCollideType )
     case DUNG_COLL_NO_COLLISION:
     case DUNG_COLL_PLAYER:
         m_vVel = delta;
-        JLog( LOG_LEVEL_DEBUG, true, "hit %d change course <%.2f %.2f>\n", dwCollideType, VEC_EXPAND(m_vVel));
+        JLog( LOG_LEVEL_NOISE, true, "hit %d change course <%.2f %.2f>\n", dwCollideType,
+              VEC_EXPAND( m_vVel ) );
         break;
     default:
-        JLog( LOG_LEVEL_DEBUG, true, "hit %d steady course <%.2f %.2f>\n",dwCollideType, VEC_EXPAND(m_vVel));
+        JLog( LOG_LEVEL_NOISE, true, "hit %d steady course <%.2f %.2f>\n", dwCollideType,
+              VEC_EXPAND( m_vVel ) );
         // m_vVel.Init();
         break;
     }

--- a/src/ClockStepState.cpp
+++ b/src/ClockStepState.cpp
@@ -37,7 +37,7 @@ int CClockStepState::OnHandleKey( SDL_Keysym *keysym )
 int CClockStepState::OnHandleTick( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling TICK modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling TICK modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -47,7 +47,7 @@ int CClockStepState::OnHandleTick( SDL_Keysym *keysym )
 
     if( retval == JCOMPLETESTATE )
     {
-        JLog( LOG_LEVEL_INFO, true, "TICK modifier complete, CLOCKSTEP state to next TICK\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "TICK modifier complete, CLOCKSTEP state to next TICK\n" );
         DoTick();
         m_eCurModifier = CLOCKSTEP_TICK;
         m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
@@ -55,12 +55,12 @@ int CClockStepState::OnHandleTick( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_WARN, true, "CLOCK still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_INFO, true, "CLOCK still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_DEBUG, true, "TICK modifier got a valid key\n" );
+    JLog( LOG_LEVEL_NOISE, true, "TICK modifier got a valid key\n" );
     g_pGame->GetEnd()->Clear();
     DoTick();
 
@@ -69,7 +69,7 @@ int CClockStepState::OnHandleTick( SDL_Keysym *keysym )
 
 int CClockStepState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_INFO, true, "Initializing CLOCKSTEP state...\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Initializing CLOCKSTEP state...\n" );
 
     g_pGame->GetStats()->Clear();
     DoTick();

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -335,7 +335,7 @@ public:
 
     void Init()
     {
-        JLog( LOG_LEVEL_WARN, true, "expecting %d strings...", NUM_STRINGS );
+        JLog( LOG_LEVEL_INFO, true, "expecting %d strings...", NUM_STRINGS );
         m_StringTable = new TextEntry[NUM_STRINGS];
         int i = 0;
         // Monster flags
@@ -518,7 +518,7 @@ public:
 
         if( i == NUM_STRINGS )
         {
-            JLog( LOG_LEVEL_WARN, false, "Success!\n" );
+            JLog( LOG_LEVEL_INFO, false, "Success!\n" );
         }
         else
         {

--- a/src/DisplayText.cpp
+++ b/src/DisplayText.cpp
@@ -81,7 +81,7 @@ void CDisplayText::DrawStr( int x, int y, char *szString )
 
 void CDisplayText::DrawStr( int x, int y, bool bBoundsCheck, int dwYMax, char *szString )
 {
-    JLog( LOG_LEVEL_DEBUG, true, "Trying to draw string: %s\n", szString );
+    JLog( LOG_LEVEL_NOISE, true, "Trying to draw string: %s\n", szString );
     JVector vScreen( (float)x, (float)y );
     JVector vSize( (float)FONT_DRAW_W, (float)FONT_DRAW_H );
     char *ptr = szString;

--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -238,15 +238,15 @@ JResult CDungeon::PlaceStairs( const int desired, const int type )
     while( count < desired )
     {
         bStairsSpawned = false;
-        JLog( LOG_LEVEL_WARN, false, "Trying to spawn stairs type: %d...", type );
+        JLog( LOG_LEVEL_INFO, false, "Trying to spawn stairs type: %d...", type );
         JVector vTryPos;
         while( !bStairsSpawned )
         {
-            JLog( LOG_LEVEL_WARN, false, "." );
+            JLog( LOG_LEVEL_INFO, false, "." );
             vTryPos.Init( (float)( Util::GetRandom( 0, DUNG_WIDTH - 1 ) ),
                           (float)( Util::GetRandom( 0, DUNG_HEIGHT - 1 ) ) );
 
-            // JLog( LOG_LEVEL_DEBUG, false, "Trying to spawn item type: %d at <%.2f %.2f>...\n",
+            // JLog( LOG_LEVEL_NOISE, false, "Trying to spawn item type: %d at <%.2f %.2f>...\n",
             // m_md->m_dwType, vTryPos.x, vTryPos.y ); g_pGame->GetMsgs()->Printf( "Trying to spawn
             // item type: %d at
             // <%.2f %.2f>...\n", m_md->m_dwType, vTryPos.x, vTryPos.y );
@@ -255,7 +255,7 @@ JResult CDungeon::PlaceStairs( const int desired, const int type )
             {
                 GetTile( vTryPos )->m_dtd = &m_dtdlist[type];
                 bStairsSpawned = true;
-                JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n",
+                JLog( LOG_LEVEL_INFO, false, "Success! Spawned at <%.2f %.2f>\n",
                       VEC_EXPAND( vTryPos ) );
             }
         }
@@ -269,7 +269,7 @@ JResult CDungeon::PlaceItems( const int depth )
     m_llItems = new JLinkList<CItem>;
 
     int desired_items = int( m_fOpenFloorArea * DUNG_CFG_ITEMS_PER_LEVEL );
-    JLog( LOG_LEVEL_WARN, false, "\nPossible spawn points: %0.2f  desired items: %d\n",
+    JLog( LOG_LEVEL_INFO, false, "\nPossible spawn points: %0.2f  desired items: %d\n",
           m_fOpenFloorArea, desired_items );
 
     while( desired_items > 0 )
@@ -277,12 +277,12 @@ JResult CDungeon::PlaceItems( const int depth )
         int which_item = ChooseItemForDepth( depth );
         if( which_item == ITEM_IDX_INVALID )
         {
-            JLog( LOG_LEVEL_INFO, true, "Couldn't find a suitable item.\n" );
+            JLog( LOG_LEVEL_DEBUG, true, "Couldn't find a suitable item.\n" );
             continue;
         }
 
         CItemDef *chosen_item = m_llItemDefs->GetLink( which_item )->m_lpData;
-        JLog( LOG_LEVEL_DEBUG, true, "Choosing item %d, called %s", which_item,
+        JLog( LOG_LEVEL_NOISE, true, "Choosing item %d, called %s", which_item,
               chosen_item->m_szName );
 
         CItem::CreateItem( chosen_item );
@@ -298,7 +298,7 @@ JResult CDungeon::SpawnMonsters( const int depth )
     m_llMonsters = new JLinkList<CMonster>;
 
     int desired_monsters = int( m_fOpenFloorArea * DUNG_CFG_MONSTERS_PER_LEVEL );
-    JLog( LOG_LEVEL_WARN, false, "\nPossible spawn points: %0.2f  desired monsters: %d\n",
+    JLog( LOG_LEVEL_INFO, false, "\nPossible spawn points: %0.2f  desired monsters: %d\n",
           m_fOpenFloorArea, desired_monsters );
 
     while( desired_monsters > 0 )
@@ -326,7 +326,7 @@ CMonsterDef *CDungeon::GetMonsterDef( int which_monster )
 {
     if( which_monster == MON_IDX_INVALID || which_monster >= MON_IDX_MAX )
     {
-        JLog( LOG_LEVEL_INFO, true, "Couldn't find a suitable monster.\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "Couldn't find a suitable monster.\n" );
         return NULL;
     }
     return m_llMonsterDefs->GetLink( which_monster )->m_lpData;
@@ -335,7 +335,7 @@ CMonsterDef *CDungeon::GetMonsterDef( int which_monster )
 bool CDungeon::SpawnMonster( int which_monster )
 {
     CMonsterDef *chosen_monster = GetMonsterDef( which_monster );
-    JLog( LOG_LEVEL_DEBUG, true, "Choosing monster %d, called %s...", which_monster,
+    JLog( LOG_LEVEL_NOISE, true, "Choosing monster %d, called %s...", which_monster,
           chosen_monster->m_szName );
 
     CMonster::CreateMonster( chosen_monster );
@@ -387,7 +387,7 @@ int CDungeon::ChooseMonsterForDepth( const int depth )
 
 JResult CDungeon::OnChangeLevel( const int delta )
 {
-    JLog( LOG_LEVEL_WARN, false, "Changing level...\n" );
+    JLog( LOG_LEVEL_INFO, false, "Changing level...\n" );
     // Clean up old level, then
     TerminateLevel();
 
@@ -395,8 +395,8 @@ JResult CDungeon::OnChangeLevel( const int delta )
     CreateNewLevel( delta );
     g_pGame->GetPlayer()->m_bHasSpawned = false;
     g_pGame->GetPlayer()->SpawnPlayer();
-    JLog( LOG_LEVEL_WARN, false, "done.\n" );
-    JLog( LOG_LEVEL_WARN, false, "You pass through a one-way door, to arrive on level %d.\n",
+    JLog( LOG_LEVEL_INFO, false, "done.\n" );
+    JLog( LOG_LEVEL_INFO, false, "You pass through a one-way door, to arrive on level %d.\n",
           depth );
     g_pGame->GetMsgs()->Printf( "You pass through a one-way door, to arrive on level %d.\n",
                                 depth );
@@ -633,7 +633,8 @@ void CDungeon::RemoveMonster( CMonster *pMon )
 
 int CDungeon::IsWalkableFor( JVector &vPos, bool isPlayer )
 {
-    if( !vPos.IsWithinWorld() ) return false;
+    if( !vPos.IsWithinWorld() )
+        return false;
     // Check for someone else standing there first (handles things that can walk thru walls)
     CDungeonTile *curTile = GetTile( vPos );
     if( curTile == NULL )
@@ -644,7 +645,7 @@ int CDungeon::IsWalkableFor( JVector &vPos, bool isPlayer )
     if( curTile->m_pCurMonster != NULL )
     {
         // Monsters can collide with other monsters
-        JLog( LOG_LEVEL_INFO, true, "Monster attacking other monsters is not implemented yet.\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "Monster attacking other monsters is not implemented yet.\n" );
         return DUNG_COLL_MONSTER;
     }
     else if( !isPlayer && g_pGame->GetPlayer() && g_pGame->GetPlayer()->m_bHasSpawned &&
@@ -708,7 +709,7 @@ int CDungeon::CanPlaceItemAt( JVector &vPos )
     CDungeonTile *curTile = GetTile( vPos );
     if( curTile == NULL )
     {
-        JLog( LOG_LEVEL_INFO, true, "Hey! That's a bad tile.\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "Hey! That's a bad tile.\n" );
         return false;
     }
     if( curTile->m_pCurItem != NULL )

--- a/src/DungeonMap.cpp
+++ b/src/DungeonMap.cpp
@@ -41,33 +41,33 @@ void CDungeonMap::CreateDungeon( const int depth )
     // Do something with the depth, here...
     if( depth > 100 )
     {
-        JLog( LOG_LEVEL_WARN, false, "You have a bad feeling about this level...\n" );
+        JLog( LOG_LEVEL_INFO, false, "You have a bad feeling about this level...\n" );
     }
     else if( depth > 75 )
     {
-        JLog( LOG_LEVEL_WARN, false, "Just another walk in the park.\n" );
+        JLog( LOG_LEVEL_INFO, false, "Just another walk in the park.\n" );
     }
     else if( depth > 50 )
     {
-        JLog( LOG_LEVEL_WARN, false,
+        JLog( LOG_LEVEL_INFO, false,
               "It is my firm belief that this level contains monsters, of one kind or another.\n" );
     }
     else if( depth > 25 )
     {
-        JLog( LOG_LEVEL_WARN, false,
+        JLog( LOG_LEVEL_INFO, false,
               "This level goes together like wham-a-lamma-lamma and bop-she-bop-she-bop.\n" );
     }
     else if( depth > 10 )
     {
-        JLog( LOG_LEVEL_WARN, false, "What was *that*?!.\n" );
+        JLog( LOG_LEVEL_INFO, false, "What was *that*?!.\n" );
     }
     else if( depth > 5 )
     {
-        JLog( LOG_LEVEL_WARN, false, "Please keep hands and arms inside the carriage.\n" );
+        JLog( LOG_LEVEL_INFO, false, "Please keep hands and arms inside the carriage.\n" );
     }
     else if( depth <= 0 )
     {
-        JLog( LOG_LEVEL_WARN, false, "Error, levels don't go below 0.\n" );
+        JLog( LOG_LEVEL_INFO, false, "Error, levels don't go below 0.\n" );
     }
 #ifdef FIXED_DUNGEON
     //    For setpiece rooms, treasure rooms, &c
@@ -121,7 +121,7 @@ bool CDungeonMap::CheckInterior( const JRect area )
             vCheck.x = x;
             if( GetTile( vCheck )->GetType() != DUNG_IDX_WALL )
             {
-                JLog( LOG_LEVEL_DEBUG, true,
+                JLog( LOG_LEVEL_NOISE, true,
                       "interior check failed. Wanted <%d %d, %d %d>, but <%d %d> was %d\n",
                       RECT_EXPAND( area ), x, y, m_dmtTiles[y * DUNG_WIDTH + x].GetType() );
                 return false;
@@ -162,25 +162,25 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
     // TweakBorders(rcCheck, direction);
     if( rcCheck.top <= 0 )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, top=0\n",
+        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, top=0\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
     else if( rcCheck.bottom >= DUNG_HEIGHT - 1 )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, bottom=max\n",
+        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, bottom=max\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
     else if( rcCheck.left <= 0 )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, left=0\n",
+        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, left=0\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
     else if( rcCheck.right >= DUNG_WIDTH - 1 )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, right=max\n",
+        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, right=max\n",
               RECT_EXPAND( rcCheck ) );
         return false;
     }
@@ -188,7 +188,7 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
     JRect rcEdges( rcCheck.left - 1, rcCheck.top - 1, rcCheck.right + 1, rcCheck.bottom + 1 );
     if( !rcEdges.IsInWorld() )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "border failed: <%d %d, %d %d>, edges fail.\n",
+        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, edges fail.\n",
               RECT_EXPAND( rcEdges ) );
         return false;
     }
@@ -202,7 +202,7 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
             int type = GetTile( vCheck )->GetType();
             if( type != DUNG_IDX_WALL && !IsDoor( type ) )
             {
-                JLog( LOG_LEVEL_DEBUG, true,
+                JLog( LOG_LEVEL_NOISE, true,
                       "border check failed. Wanted <%d %d, %d %d>, but <%d %d> was %d\n",
                       RECT_EXPAND( area ), x, y, m_dmtTiles[y * DUNG_WIDTH + x].GetType() );
                 return false;
@@ -297,7 +297,7 @@ void CDungeonMap::FillArea( const Uint8 type, JRect *rcFill, const int direction
     // Now light the borders
     if( type != DUNG_IDX_WALL )
     {
-        JLog( LOG_LEVEL_INFO, true, "filled: <%d %d, %d %d>\nlit <%d %d, %d %d>\n",
+        JLog( LOG_LEVEL_DEBUG, true, "filled: <%d %d, %d %d>\nlit <%d %d, %d %d>\n",
               RECT_EXPAND( rcLocal ), RECT_EXPAND( rcEdges ) );
 
         // L and R sides, going over-by-one in each direction
@@ -321,7 +321,7 @@ void CDungeonMap::FillArea( const Uint8 type, JRect *rcFill, const int direction
     }
 
     // you still filled rcFill squares, just that one of them was a door.
-    JLog( LOG_LEVEL_INFO, true, "filled from <%d %d> to <%d %d>\n", RECT_EXPAND( *rcFill ) );
+    JLog( LOG_LEVEL_DEBUG, true, "filled from <%d %d> to <%d %d>\n", RECT_EXPAND( *rcFill ) );
 
     if( bIsHallway )
     {
@@ -389,7 +389,7 @@ bool CDungeonMap::CreateOneStep()
     CDungeonCreationStep *pCurStep = pLink->m_lpData;
     CDungeonCreationStep *pNewStep = NULL;
 
-    JLog( LOG_LEVEL_INFO, true, "creating %d %s at <%d %d, %d %d>\n", pCurStep->m_dwDirection,
+    JLog( LOG_LEVEL_DEBUG, true, "creating %d %s at <%d %d, %d %d>\n", pCurStep->m_dwDirection,
           pCurStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "room" : "hallway",
           RECT_EXPAND( pCurStep->m_rcArea ) );
     // create current entity
@@ -518,7 +518,7 @@ void CDungeonMap::AddDoor( const JIVector vHall, int direction )
         sprintf( flavor, "secret " );
         door_type = DUNG_IDX_SECRET_DOOR;
     }
-    JLog( LOG_LEVEL_WARN, false, "Placing a %sdoor at <%d %d>\n", flavor, VEC_EXPAND( vDoor ) );
+    JLog( LOG_LEVEL_INFO, false, "Placing a %sdoor at <%d %d>\n", flavor, VEC_EXPAND( vDoor ) );
     GetTile( vDoor )->SetType( door_type );
 }
 
@@ -553,7 +553,7 @@ CDungeonCreationStep *CDungeonMap::MakeRoomStep( const JIVector &vPos, const int
         if( !dwDone )
         {
             // this one didn't work, need to "un-shift" the rect for the next try.
-            JLog( LOG_LEVEL_DEBUG, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
+            JLog( LOG_LEVEL_NOISE, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
                   RECT_EXPAND( pStep->m_rcArea ), RECT_EXPAND( rcTry ) );
             pStep->m_rcArea.Init( rcTry );
         }
@@ -598,7 +598,7 @@ CDungeonCreationStep *CDungeonMap::MakeHallStep( const JIVector &vPos, const int
         if( !dwDone )
         {
             // this one didn't work, need to "un-shift" the rect for the next try.
-            JLog( LOG_LEVEL_DEBUG, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
+            JLog( LOG_LEVEL_NOISE, true, "un-shifting <%d %d, %d %d> back to <%d %d, %d %d>\n",
                   RECT_EXPAND( pStep->m_rcArea ), RECT_EXPAND( rcTry ) );
             pStep->m_rcArea.Init( rcTry );
         }
@@ -704,7 +704,7 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init(
             pStep->m_rcArea.Left() + ( Util::GetRandom( 0, pStep->m_rcArea.Width() ) ),
             pStep->m_rcArea.Top() - 2 ); // -1... does a room's rect include its walls?
-        JLog( LOG_LEVEL_DEBUG, true,
+        JLog( LOG_LEVEL_NOISE, true,
               "[%d>%d]GetWallOrigin creating north %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
@@ -714,7 +714,7 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init( pStep->m_rcArea.Left() +
                                 ( Util::GetRandom( 0, pStep->m_rcArea.Width() ) ),
                             pStep->m_rcArea.Bottom() + 2 );
-        JLog( LOG_LEVEL_DEBUG, true,
+        JLog( LOG_LEVEL_NOISE, true,
               "[%d>%d]GetWallOrigin creating south %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
@@ -724,7 +724,7 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init( pStep->m_rcArea.Left() - 2,
                             pStep->m_rcArea.Top() +
                                 ( Util::GetRandom( 0, pStep->m_rcArea.Height() ) ) );
-        JLog( LOG_LEVEL_DEBUG, true, "[%d>%d]GetWallOrigin creating west %s, starting at <%d %d>\n",
+        JLog( LOG_LEVEL_NOISE, true, "[%d>%d]GetWallOrigin creating west %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
               VEC_EXPAND( pStep->m_vPos ) );
@@ -733,7 +733,7 @@ JIVector &CDungeonMap::GetWallOrigin( CDungeonCreationStep *pStep, const int dir
         pStep->m_vPos.Init( pStep->m_rcArea.Right() + 2,
                             pStep->m_rcArea.Top() +
                                 ( Util::GetRandom( 0, pStep->m_rcArea.Height() ) ) );
-        JLog( LOG_LEVEL_DEBUG, true, "[%d>%d]GetWallOrigin creating east %s, starting at <%d %d>\n",
+        JLog( LOG_LEVEL_NOISE, true, "[%d>%d]GetWallOrigin creating east %s, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1,
               pStep->m_dwIndex == DUNG_CREATE_STEP_MAKE_ROOM ? "hall" : "room",
               VEC_EXPAND( pStep->m_vPos ) );
@@ -756,25 +756,25 @@ JIVector &CDungeonMap::GetHallOrigin( CDungeonCreationStep *pStep, int step_type
         pStep->m_vPos.Init( pStep->m_rcArea.Left(),
                             pStep->m_rcArea.Top() -
                                 modifier ); // -1... does a room's rect include its walls?
-        JLog( LOG_LEVEL_DEBUG, true,
+        JLog( LOG_LEVEL_NOISE, true,
               "[%d>%d]GetHallOrigin creating north hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;
     case DIR_SOUTH:
         pStep->m_vPos.Init( pStep->m_rcArea.Left(), pStep->m_rcArea.Bottom() + modifier );
-        JLog( LOG_LEVEL_DEBUG, true,
+        JLog( LOG_LEVEL_NOISE, true,
               "[%d>%d]GetHallOrigin creating south hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;
     case DIR_WEST:
         pStep->m_vPos.Init( pStep->m_rcArea.Left() - modifier, pStep->m_rcArea.Top() );
-        JLog( LOG_LEVEL_DEBUG, true,
+        JLog( LOG_LEVEL_NOISE, true,
               "[%d>%d]GetHallOrigin creating west hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;
     case DIR_EAST:
         pStep->m_vPos.Init( pStep->m_rcArea.Right() + modifier, pStep->m_rcArea.Top() );
-        JLog( LOG_LEVEL_DEBUG, true,
+        JLog( LOG_LEVEL_NOISE, true,
               "[%d>%d]GetHallOrigin creating east hall, starting at <%d %d>\n",
               pStep->m_dwRecurDepth, pStep->m_dwRecurDepth + 1, VEC_EXPAND( pStep->m_vPos ) );
         break;

--- a/src/EndGameState.cpp
+++ b/src/EndGameState.cpp
@@ -57,7 +57,7 @@ int CEndGameState::OnHandleKey( SDL_Keysym *keysym )
 int CEndGameState::OnHandleTomb( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling TOMB modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling TOMB modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -67,7 +67,7 @@ int CEndGameState::OnHandleTomb( SDL_Keysym *keysym )
 
     if( retval == JCOMPLETESTATE )
     {
-        JLog( LOG_LEVEL_INFO, true, "TOMB modifier complete, ENDGAME state to SCORES\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "TOMB modifier complete, ENDGAME state to SCORES\n" );
         g_pGame->GetEnd()->Clear();
         InitScores();
         DoScores();
@@ -77,12 +77,12 @@ int CEndGameState::OnHandleTomb( SDL_Keysym *keysym )
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_WARN, true, "Name cmd still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_INFO, true, "Name cmd still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_DEBUG, true, "TOMB modifier got a valid key\n" );
+    JLog( LOG_LEVEL_NOISE, true, "TOMB modifier got a valid key\n" );
     g_pGame->GetEnd()->Clear();
     DoTomb();
 
@@ -92,7 +92,7 @@ int CEndGameState::OnHandleTomb( SDL_Keysym *keysym )
 int CEndGameState::OnHandleScores( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling SCORES modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling SCORES modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -102,18 +102,18 @@ int CEndGameState::OnHandleScores( SDL_Keysym *keysym )
 
     if( retval == JCOMPLETESTATE )
     {
-        JLog( LOG_LEVEL_INFO, true, "SCORES modifier complete, ENDGAME state to INIT\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "SCORES modifier complete, ENDGAME state to INIT\n" );
         g_pGame->Quit( 0 );
     }
 
     if( retval != JSUCCESS )
     {
-        JLog( LOG_LEVEL_WARN, true, "Name cmd still waiting for a valid key.\n" );
+        JLog( LOG_LEVEL_INFO, true, "Name cmd still waiting for a valid key.\n" );
         return 0;
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_DEBUG, true, "SCORES modifier got a valid key\n" );
+    JLog( LOG_LEVEL_NOISE, true, "SCORES modifier got a valid key\n" );
     g_pGame->GetEnd()->Clear();
     DoScores();
 
@@ -122,7 +122,7 @@ int CEndGameState::OnHandleScores( SDL_Keysym *keysym )
 
 int CEndGameState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_WARN, true, "Initializing endgame state...\n" );
+    JLog( LOG_LEVEL_INFO, true, "Initializing endgame state...\n" );
 
     m_pScore->InitScore();
 

--- a/src/FileParse.cpp
+++ b/src/FileParse.cpp
@@ -247,7 +247,7 @@ CMonsterDef *CDataFile::ReadMonster( CMonsterDef &mdIn )
                 {
                     // multi-hued
                     // <<rgb1>,<rgb2>,...,<rgbn>>
-                    JLog( LOG_LEVEL_INFO, true, "Found multi-hued monster: %s\n", color );
+                    JLog( LOG_LEVEL_DEBUG, true, "Found multi-hued monster: %s\n", color );
                     mdIn.m_Colors = ParseColors( color );
 
                     mdIn.m_dwFlags |= MON_COLOR_MULTI;
@@ -382,7 +382,7 @@ CItemDef *CDataFile::ReadItem( CItemDef &idIn )
                 {
                     // multi-hued
                     // <<rgb1>,<rgb2>,...,<rgbn>>
-                    JLog( LOG_LEVEL_INFO, true, "Found multi-hued item: %s\n", color );
+                    JLog( LOG_LEVEL_DEBUG, true, "Found multi-hued item: %s\n", color );
                     idIn.m_Colors = ParseColors( color );
 
                     idIn.m_dwFlags |= ITEM_COLOR_MULTI;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -112,10 +112,10 @@ JResult CGame::Init( const char *szBasedir )
 
 void CGame::Term()
 {
-    JLog( LOG_LEVEL_WARN, true, "Terminating the game..." );
+    JLog( LOG_LEVEL_INFO, true, "Terminating the game..." );
     if( m_pRender )
     {
-        JLog( LOG_LEVEL_INFO, true, "Renderer..." );
+        JLog( LOG_LEVEL_DEBUG, true, "Renderer..." );
         m_pRender->Term();
         delete m_pRender;
         m_pRender = NULL;
@@ -123,7 +123,7 @@ void CGame::Term()
 
     if( m_pDungeon )
     {
-        JLog( LOG_LEVEL_INFO, true, "Dungeon..." );
+        JLog( LOG_LEVEL_DEBUG, true, "Dungeon..." );
         m_pDungeon->Term();
         delete m_pDungeon;
         m_pDungeon = NULL;
@@ -131,13 +131,13 @@ void CGame::Term()
 
     if( m_pPlayer )
     {
-        JLog( LOG_LEVEL_INFO, true, "Player..." );
+        JLog( LOG_LEVEL_DEBUG, true, "Player..." );
         m_pPlayer->Term();
         delete m_pPlayer;
         m_pPlayer = NULL;
     }
 
-    JLog( LOG_LEVEL_INFO, true, "States..." );
+    JLog( LOG_LEVEL_DEBUG, true, "States..." );
     if( m_pCmdState )
     {
         delete m_pCmdState;
@@ -180,7 +180,7 @@ void CGame::Term()
         m_pRestState = NULL;
     }
 
-    JLog( LOG_LEVEL_INFO, true, "Message boxes..." );
+    JLog( LOG_LEVEL_DEBUG, true, "Message boxes..." );
     if( m_pMsgsDT )
     {
         delete m_pMsgsDT;
@@ -216,7 +216,7 @@ void CGame::Term()
         delete m_pEndGameDT;
         m_pEndGameDT = NULL;
     }
-    JLog( LOG_LEVEL_INFO, true, "done.\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "done.\n" );
 }
 
 void CGame::Quit( int returncode )
@@ -516,12 +516,12 @@ void CGame::HandleEvents( int &isActive, int &done )
                 g_pGame->GetDungeon()->Zoom( -3 );
                 break;
             }
-            /*JLog( LOG_LEVEL_DEBUG, true, "Got up event type: %d which: %d button: %d state: %d at
+            /*JLog( LOG_LEVEL_NOISE, true, "Got up event type: %d which: %d button: %d state: %d at
             <%d %d>\n", event.button.type, event.button.which, event.button.button,
             event.button.state, event.button.x, event.button.y );/* */
             break;
         default:
-            JLog( LOG_LEVEL_DEBUG, true, "unhandled event type: %d\n", event.type );
+            JLog( LOG_LEVEL_NOISE, true, "unhandled event type: %d\n", event.type );
             break;
         }
     }

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -48,7 +48,7 @@ void CItem::SetCursed( int likelihood )
     int rolled = (int)Util::GetRandom( 1.0f, 100.0f );
     if( rolled < likelihood )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "Cursed! %d\n", rolled );
+        JLog( LOG_LEVEL_NOISE, true, "Cursed! %d\n", rolled );
         m_dwFlags |= ITEM_FLAG_CURSED;
         m_Color.SetColor( 255, 0, 0, 255 );
     }
@@ -62,7 +62,7 @@ void CItem::SetCursed( int likelihood )
 JResult CItem::SpawnItem( JVector vSpawnPoint )
 {
     bool bItemSpawned = false;
-    JLog( LOG_LEVEL_WARN, false, "Trying to spawn item type: %s...", m_id->m_szName );
+    JLog( LOG_LEVEL_INFO, false, "Trying to spawn item type: %s...", m_id->m_szName );
 
     if( vSpawnPoint.IsWithinWorld() )
     {
@@ -72,11 +72,11 @@ JResult CItem::SpawnItem( JVector vSpawnPoint )
     JVector vTryPos;
     while( !bItemSpawned )
     {
-        JLog( LOG_LEVEL_WARN, false, "." );
+        JLog( LOG_LEVEL_INFO, false, "." );
         vTryPos.Init( (float)( Util::GetRandom( 1, DUNG_WIDTH - 2 ) ),
                       (float)( Util::GetRandom( 1, DUNG_HEIGHT - 2 ) ) );
 
-        // JLog( LOG_LEVEL_DEBUG, false, "Trying to spawn item type: %d at <%.2f %.2f>...\n",
+        // JLog( LOG_LEVEL_NOISE, false, "Trying to spawn item type: %d at <%.2f %.2f>...\n",
         // m_md->m_dwType, vTryPos.x, vTryPos.y ); g_pGame->GetMsgs()->Printf( "Trying to spawn item
         // type: %d at <%.2f
         // %.2f>...\n", m_md->m_dwType, vTryPos.x, vTryPos.y );
@@ -96,7 +96,7 @@ JResult CItem::SpawnAt( JVector vSpawnPoint )
         m_vPos = vSpawnPoint;
         g_pGame->GetDungeon()->GetTile( m_vPos )->m_pCurItem = this;
 
-        JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n", VEC_EXPAND( m_vPos ) );
+        JLog( LOG_LEVEL_INFO, false, "Success! Spawned at <%.2f %.2f>\n", VEC_EXPAND( m_vPos ) );
         // g_pGame->GetMsgs()->Printf( "Success!\n" );
 
         return JSUCCESS;

--- a/src/JLinkList.h
+++ b/src/JLinkList.h
@@ -224,6 +224,11 @@ public:
             return NULL;
         while( count < which_link )
         {
+            if( curr_link->m_dwIndex == which_link )
+            {
+                return curr_link;
+            }
+
             if( curr_link->next == NULL )
             {
                 if( bForceValid )

--- a/src/JLog.h
+++ b/src/JLog.h
@@ -7,6 +7,8 @@ static const char *Level( eLogLevel log_level )
 {
     switch( log_level )
     {
+    case LOG_LEVEL_NOISE:
+        return "NOISE";
     case LOG_LEVEL_DEBUG:
         return "DEBUG";
     case LOG_LEVEL_INFO:
@@ -39,7 +41,7 @@ static JResult JLog( eLogLevel eLogLevel, bool verbose, const char *format, ... 
         vprintf( mod_format, args );
         va_end( args );
     }
-    if( eLogLevel >= LOG_LEVEL_WARN )
+    if( eLogLevel >= LOG_LEVEL_INFO )
     {
         return JBOGUSKEY;
     }

--- a/src/JLog.h
+++ b/src/JLog.h
@@ -41,7 +41,7 @@ static JResult JLog( eLogLevel eLogLevel, bool verbose, const char *format, ... 
         vprintf( mod_format, args );
         va_end( args );
     }
-    if( eLogLevel >= LOG_LEVEL_INFO )
+    if( eLogLevel >= LOG_LEVEL_WARN )
     {
         return JBOGUSKEY;
     }

--- a/src/JMDefs.h
+++ b/src/JMDefs.h
@@ -23,8 +23,9 @@ typedef unsigned char uint8;
 enum eLogLevel
 {
     LOG_LEVEL_INVALID = -1,
-    LOG_LEVEL_DEBUG = 0,
-    LOG_LEVEL_INFO = 1,
+    LOG_LEVEL_NOISE = 0,
+    LOG_LEVEL_DEBUG = 1,
+    LOG_LEVEL_INFO,
     LOG_LEVEL_WARN,
     LOG_LEVEL_ERROR,
     LOG_LEVEL_MAX

--- a/src/JRect.h
+++ b/src/JRect.h
@@ -80,7 +80,7 @@ public:
         else
             top = bottom - dwHeight;
     };
-    
+
     bool IsValidRect()
     {
         if( left > right || top > bottom )
@@ -104,7 +104,7 @@ public:
 
     bool IsWithinWorld()
     {
-        if( left < 1 || right >= DUNG_WIDTH-1 || top < 1 || bottom >= DUNG_HEIGHT-1 )
+        if( left < 1 || right >= DUNG_WIDTH - 1 || top < 1 || bottom >= DUNG_HEIGHT - 1 )
         {
             return false;
         }

--- a/src/JVector.h
+++ b/src/JVector.h
@@ -145,7 +145,10 @@ public:
     }
 
     bool IsInWorld() { return ( x >= 0 && x < ( DUNG_WIDTH ) && y >= 0 && y < ( DUNG_HEIGHT ) ); }
-    bool IsWithinWorld() { return ( x >= 1 && x < ( DUNG_WIDTH -1 ) && y >= 1 && y < ( DUNG_HEIGHT -1 ) ); }
+    bool IsWithinWorld()
+    {
+        return ( x >= 1 && x < ( DUNG_WIDTH - 1 ) && y >= 1 && y < ( DUNG_HEIGHT - 1 ) );
+    }
 
     void Init( T inx = 0, T iny = 0 )
     {
@@ -166,7 +169,7 @@ public:
             y /= len;
         }
     }
-    void printvec( const char *label ) { JLog( LOG_LEVEL_INFO, true, "%s: %f %f ", label, x, y ); }
+    void printvec( const char *label ) { JLog( LOG_LEVEL_DEBUG, true, "%s: %f %f ", label, x, y ); }
 };
 
 typedef TVector2<int> JIVector;

--- a/src/ModState.cpp
+++ b/src/ModState.cpp
@@ -31,7 +31,7 @@ int CModState::OnHandleKey( SDL_Keysym *keysym )
 int CModState::OnHandleOpen( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling OPEN modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling OPEN modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -48,7 +48,7 @@ int CModState::OnHandleOpen( SDL_Keysym *keysym )
     }
 
     // We got a directional key; do an "open" in that direction
-    JLog( LOG_LEVEL_DEBUG, true, "OPEN modifier got a directional\n" );
+    JLog( LOG_LEVEL_NOISE, true, "OPEN modifier got a directional\n" );
     if( TestOpen() )
     {
         if( DoOpen() )
@@ -66,7 +66,7 @@ int CModState::OnHandleOpen( SDL_Keysym *keysym )
         g_pGame->GetMsgs()->Printf( "I do not see anything to open there.\n" );
     }
 
-    JLog( LOG_LEVEL_INFO, true,
+    JLog( LOG_LEVEL_DEBUG, true,
           "OPEN modifier resetting game state to COMMAND, OPEN state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
@@ -76,7 +76,7 @@ int CModState::OnHandleOpen( SDL_Keysym *keysym )
 int CModState::OnHandleClose( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling CLOSE modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling CLOSE modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -93,7 +93,7 @@ int CModState::OnHandleClose( SDL_Keysym *keysym )
     }
 
     // We got a directional key; do an "open" in that direction
-    JLog( LOG_LEVEL_DEBUG, true, "CLOSE modifier got a directional\n" );
+    JLog( LOG_LEVEL_NOISE, true, "CLOSE modifier got a directional\n" );
     if( TestClose() )
     {
         if( DoClose() )
@@ -111,7 +111,7 @@ int CModState::OnHandleClose( SDL_Keysym *keysym )
         g_pGame->GetMsgs()->Printf( "I do not see anything to close there.\n" );
     }
 
-    JLog( LOG_LEVEL_INFO, true,
+    JLog( LOG_LEVEL_DEBUG, true,
           "CLOSE modifier resetting game state to COMMAND, CLOSE state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
@@ -121,7 +121,7 @@ int CModState::OnHandleClose( SDL_Keysym *keysym )
 int CModState::OnHandleTunnel( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling TUNNEL modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling TUNNEL modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -138,7 +138,7 @@ int CModState::OnHandleTunnel( SDL_Keysym *keysym )
     }
 
     // We got a directional key; do an "open" in that direction
-    JLog( LOG_LEVEL_DEBUG, true, "TUNNEL modifier got a directional\n" );
+    JLog( LOG_LEVEL_NOISE, true, "TUNNEL modifier got a directional\n" );
     if( TestTunnel() )
     {
         if( DoTunnel() )
@@ -156,7 +156,7 @@ int CModState::OnHandleTunnel( SDL_Keysym *keysym )
         g_pGame->GetMsgs()->Printf( "Tunnel through what? Empty air?.\n" );
     }
 
-    JLog( LOG_LEVEL_INFO, true,
+    JLog( LOG_LEVEL_DEBUG, true,
           "TUNNEL modifier resetting game state to COMMAND, TUNNEL state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
@@ -165,7 +165,7 @@ int CModState::OnHandleTunnel( SDL_Keysym *keysym )
 
 int CModState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_INFO, true, "Initializing modify state...\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Initializing modify state...\n" );
     if( !m_cCommand )
     {
         m_cCommand = keysym->sym;

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -64,7 +64,7 @@ JResult CMonster::CreateMonster( CMonsterDef *pmd, JVector vSpawnPoint, bool bNe
         }
         else
         {
-            JLog(LOG_LEVEL_WARN, true, "spawn failed.\n");
+            JLog( LOG_LEVEL_WARN, true, "spawn failed.\n" );
             // That spawn failed; clean up
             // delete pMon;
             // pMon = NULL;
@@ -99,17 +99,17 @@ JResult CMonster::InitAndSpawn( CMonsterDef *pmd, JVector vSpawnPoint )
 JResult CMonster::SpawnMonster( JVector vSpawnPoint )
 {
     bool bMonsterSpawned = false;
-    JLog( LOG_LEVEL_WARN, false, "Trying to spawn monster type: %s...", m_md->m_szName );
+    JLog( LOG_LEVEL_INFO, false, "Trying to spawn monster type: %s...", m_md->m_szName );
     if( vSpawnPoint.IsWithinWorld() )
     {
-        JLog(LOG_LEVEL_WARN, true, "given <%.2f %.2f>...", VEC_EXPAND(vSpawnPoint));
+        JLog( LOG_LEVEL_INFO, true, "given <%.2f %.2f>...", VEC_EXPAND( vSpawnPoint ) );
         return SpawnAt( vSpawnPoint );
     }
 
     JVector vTryPos;
     while( !bMonsterSpawned )
     {
-        JLog( LOG_LEVEL_WARN, false, "." );
+        JLog( LOG_LEVEL_INFO, false, "." );
         vTryPos.Init( (float)( Util::GetRandom( 1, DUNG_WIDTH - 2 ) ),
                       (float)( Util::GetRandom( 1, DUNG_HEIGHT - 2 ) ) );
 
@@ -124,12 +124,12 @@ JResult CMonster::SpawnMonster( JVector vSpawnPoint )
 
 JResult CMonster::SpawnAt( JVector vPos )
 {
-    // JLog(LOG_LEVEL_WARN, true, "trying <%.2f %.2f>...", VEC_EXPAND(vPos));
+    // JLog(LOG_LEVEL_INFO, true, "trying <%.2f %.2f>...", VEC_EXPAND(vPos));
     if( g_pGame->GetDungeon()->IsWalkableFor( vPos ) == DUNG_COLL_NO_COLLISION )
     {
         SetPos( vPos );
         g_pGame->GetDungeon()->GetTile( vPos )->m_pCurMonster = this;
-        JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n", VEC_EXPAND( vPos ) );
+        JLog( LOG_LEVEL_INFO, false, "Success! Spawned at <%.2f %.2f>\n", VEC_EXPAND( vPos ) );
         // g_pGame->GetMsgs()->Printf( "Success!\n" );
 
         return JSUCCESS;
@@ -141,7 +141,7 @@ float CMonster::Attack()
 {
     float fRoll = Util::Roll( "1d100" );
 
-    JLog( LOG_LEVEL_WARN, true, "%s rolled: %.2f\n", GetName(), fRoll );
+    JLog( LOG_LEVEL_INFO, true, "%s rolled: %.2f\n", GetName(), fRoll );
 
     return fRoll;
 }
@@ -152,7 +152,7 @@ float CMonster::Damage( float fDamageMult )
     float fDamageModifier = 0.0f;
 
     float fDamage = ( Util::Roll( szDamage ) + fDamageModifier ) * fDamageMult;
-    JLog( LOG_LEVEL_WARN, true, "%s did %.2f damage (damagemult: %.2f). ", GetName(), fDamage,
+    JLog( LOG_LEVEL_INFO, true, "%s did %.2f damage (damagemult: %.2f). ", GetName(), fDamage,
           fDamageMult );
 
     return fDamage;
@@ -175,7 +175,7 @@ int CMonster::TakeDamage( float fDamage )
         retval = STATUS_DEAD;
     }
 
-    JLog( LOG_LEVEL_WARN, true, "Remaining HP: %.2f \n", m_fCurHP );
+    JLog( LOG_LEVEL_INFO, true, "Remaining HP: %.2f \n", m_fCurHP );
 
     return retval;
 }
@@ -183,7 +183,7 @@ int CMonster::TakeDamage( float fDamage )
 // draw routines
 void CMonster::Breed()
 {
-    if( ( m_md->m_dwFlags & MON_FLAG_BREED ) != MON_FLAG_BREED ) 
+    if( ( m_md->m_dwFlags & MON_FLAG_BREED ) != MON_FLAG_BREED )
         return;
 
     if( g_pGame->GetTime() < m_fLastBreed + BREED_INTERVAL )
@@ -191,19 +191,19 @@ void CMonster::Breed()
 
     if( m_dwFecundity > 0 )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "still going: %d ", m_dwFecundity );
+        JLog( LOG_LEVEL_NOISE, true, "still going: %d ", m_dwFecundity );
         if( Util::GetRandom( 0.0f, 1.0f ) <= BREED_CHANCE )
         {
-            JLog( LOG_LEVEL_WARN, false, "spawnd!" );
+            JLog( LOG_LEVEL_INFO, false, "spawnd!" );
             // Spawn a new copy
             CreateMonster( m_md, GetPos(), true );
         }
-        JLog( LOG_LEVEL_DEBUG, false, "\n" );
+        JLog( LOG_LEVEL_NOISE, false, "\n" );
         m_dwFecundity--;
     }
     else
     {
-        JLog( LOG_LEVEL_WARN, true, "sterilizing\n" );
+        JLog( LOG_LEVEL_INFO, true, "sterilizing\n" );
         // sterilize
         m_md->m_dwFlags = m_md->m_dwFlags & ~MON_FLAG_BREED;
     }

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -74,15 +74,15 @@ void CPlayer::PostDraw() { g_pGame->GetDungeon()->PostDraw(); }
 
 JResult CPlayer::SpawnPlayer()
 {
-    JLog( LOG_LEVEL_WARN, false, "\nTrying to spawn player..." );
+    JLog( LOG_LEVEL_INFO, false, "\nTrying to spawn player..." );
     JVector vTryPos;
     while( !m_bHasSpawned )
     {
-        JLog( LOG_LEVEL_WARN, false, "." );
+        JLog( LOG_LEVEL_INFO, false, "." );
         vTryPos.Init( (float)Util::GetRandom( 0, DUNG_WIDTH - 1 ),
                       (float)Util::GetRandom( 0, DUNG_HEIGHT - 1 ) );
 
-        // JLog( LOG_LEVEL_DEBUG, true, "Trying to spawn player at <%.2f %.2f>...\n", vTryPos.x,
+        // JLog( LOG_LEVEL_NOISE, true, "Trying to spawn player at <%.2f %.2f>...\n", vTryPos.x,
         //       vTryPos.y );
         // g_pGame->GetMsgs()->Printf( "Trying to spawn player at <%.2f %.2f>...\n", vTryPos.x,
         // vTryPos.y );
@@ -92,7 +92,7 @@ JResult CPlayer::SpawnPlayer()
         {
             m_vPos = vTryPos;
             m_bHasSpawned = true;
-            JLog( LOG_LEVEL_WARN, false, "Success! Spawned at <%.2f %.2f>\n",
+            JLog( LOG_LEVEL_INFO, false, "Success! Spawned at <%.2f %.2f>\n",
                   VEC_EXPAND( m_vPos ) );
             // g_pGame->GetMsgs()->Printf( "Success!\n" );
         }
@@ -250,7 +250,7 @@ float CPlayer::Attack()
     float fRoll = Util::Roll( "1d100" );
     float fHitMod = g_pGame->GetPlayer()->m_fToHitModifier;
 
-    JLog( LOG_LEVEL_WARN, true, "You rolled: %.2f, +to-hit Bonus: %.2f = Total: %.2f\n", fRoll,
+    JLog( LOG_LEVEL_INFO, true, "You rolled: %.2f, +to-hit Bonus: %.2f = Total: %.2f\n", fRoll,
           fHitMod, fRoll + fHitMod );
 
     fRoll += fHitMod;
@@ -261,7 +261,7 @@ float CPlayer::Attack()
 float CPlayer::Damage( float fDamageMult )
 {
     float fDamage = ( Util::Roll( m_szDamage ) + m_fDamageModifier ) * fDamageMult;
-    JLog( LOG_LEVEL_WARN, true, "You did %.2f damage (damagemult: %.2f). ", fDamage, fDamageMult );
+    JLog( LOG_LEVEL_INFO, true, "You did %.2f damage (damagemult: %.2f). ", fDamage, fDamageMult );
 
     return fDamage;
 }
@@ -308,13 +308,13 @@ int CPlayer::TakeDamage( float fDamage, char *szMon )
         memset( m_szKilledBy, 0, strlen( szMon ) + 1 );
         strcpy( m_szKilledBy, szMon );
         // This is the end of the game; make the game end on next update.
-        JLog( LOG_LEVEL_WARN, true,
+        JLog( LOG_LEVEL_INFO, true,
               "%s died on dungeon level %d, while level %d, killed by a %s.\n", m_szName,
               g_pGame->GetDungeon()->depth, (int)m_fLevel, m_szKilledBy );
         g_pGame->SetState( STATE_ENDGAME );
     }
 
-    JLog( LOG_LEVEL_WARN, true, "Remaining HP: %.2f \n", m_fCurHitPoints );
+    JLog( LOG_LEVEL_INFO, true, "Remaining HP: %.2f \n", m_fCurHitPoints );
 
     return retval;
 }

--- a/src/RestState.cpp
+++ b/src/RestState.cpp
@@ -34,7 +34,7 @@ int CRestState::OnHandleKey( SDL_Keysym *keysym )
 int CRestState::OnHandleTick( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling TICK modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling TICK modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -45,7 +45,7 @@ int CRestState::OnHandleTick( SDL_Keysym *keysym )
 
     if( retval == JCOMPLETESTATE )
     {
-        JLog( LOG_LEVEL_INFO, true, "TICK modifier complete, REST state to next TICK\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "TICK modifier complete, REST state to next TICK\n" );
         DoTick();
         m_eCurModifier = REST_TICK;
         m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
@@ -58,7 +58,7 @@ int CRestState::OnHandleTick( SDL_Keysym *keysym )
     }
 
     // We got a valid key
-    JLog( LOG_LEVEL_DEBUG, true, "TICK modifier got a valid key\n" );
+    JLog( LOG_LEVEL_NOISE, true, "TICK modifier got a valid key\n" );
     DoTick();
 
     return 0;
@@ -66,7 +66,7 @@ int CRestState::OnHandleTick( SDL_Keysym *keysym )
 
 int CRestState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_INFO, true, "Initializing REST state...\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Initializing REST state...\n" );
 
     DoTick();
     m_eCurModifier = REST_TICK;
@@ -101,7 +101,7 @@ bool CRestState::DoTick()
     m_dwClock++;
     if( g_pGame->GetPlayer()->m_bIsRested || g_pGame->GetPlayer()->m_bIsDisturbed )
     {
-        JLog( LOG_LEVEL_INFO, true, "REST state complete, reset to CMD state.\n" );
+        JLog( LOG_LEVEL_DEBUG, true, "REST state complete, reset to CMD state.\n" );
         ResetToState( STATE_COMMAND );
     }
     g_pGame->SetReadyForUpdate( true );

--- a/src/StringInputState.cpp
+++ b/src/StringInputState.cpp
@@ -38,7 +38,7 @@ int CStringInputState::OnHandleKey( SDL_Keysym *keysym )
 int CStringInputState::OnHandleName( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling NAME modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling NAME modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -48,7 +48,7 @@ int CStringInputState::OnHandleName( SDL_Keysym *keysym )
 
     if( retval == JCOMPLETESTATE )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_DEBUG, true,
               "NAME modifier resetting game state to COMMAND, NAME state to INIT\n" );
         // One way or another, we're done with this state now.
         g_pGame->GetPlayer()->SetName( m_szInput );
@@ -65,7 +65,7 @@ int CStringInputState::OnHandleName( SDL_Keysym *keysym )
     }
 
     // We got a alpha key; append it to the name
-    JLog( LOG_LEVEL_DEBUG, true, "NAME modifier got a alpha\n" );
+    JLog( LOG_LEVEL_NOISE, true, "NAME modifier got a alpha\n" );
     g_pGame->GetMsgs()->Clear();
     g_pGame->GetMsgs()->Printf( "Character Name: %s", m_szInput );
 
@@ -75,7 +75,7 @@ int CStringInputState::OnHandleName( SDL_Keysym *keysym )
 int CStringInputState::OnHandleHaggle( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling HAGGLE modifier\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling HAGGLE modifier\n" );
     retval = OnBaseHandleKey( keysym );
 
     if( retval == JRESETSTATE )
@@ -91,7 +91,7 @@ int CStringInputState::OnHandleHaggle( SDL_Keysym *keysym )
     }
 
     // We got a numeric key; add to haggle number
-    JLog( LOG_LEVEL_DEBUG, true, "HAGGLE modifier got a numeric\n" );
+    JLog( LOG_LEVEL_NOISE, true, "HAGGLE modifier got a numeric\n" );
     if( TestHaggle() )
     {
         if( DoHaggle() )
@@ -112,7 +112,7 @@ int CStringInputState::OnHandleHaggle( SDL_Keysym *keysym )
 
     if( retval == JRESETSTATE )
     {
-        JLog( LOG_LEVEL_INFO, true,
+        JLog( LOG_LEVEL_DEBUG, true,
               "HAGGLE modifier resetting game state to COMMAND, HAGGLE state to INIT\n" );
         // One way or another, we're done with this state now.
         ResetToState( STATE_COMMAND );
@@ -122,7 +122,7 @@ int CStringInputState::OnHandleHaggle( SDL_Keysym *keysym )
 
 int CStringInputState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_INFO, true, "Initializing modify state...\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Initializing modify state...\n" );
     if( !m_cCommand )
     {
         m_cCommand = keysym->sym;
@@ -177,7 +177,7 @@ int CStringInputState::OnBaseHandleKey( SDL_Keysym *keysym )
     else if( keysym->sym == SDLK_RETURN )
     {
         // actually set the string on the place
-        JLog( LOG_LEVEL_INFO, true, "you entered: <%s>\n", m_szInput );
+        JLog( LOG_LEVEL_DEBUG, true, "you entered: <%s>\n", m_szInput );
         return JCOMPLETESTATE;
     }
     else if( keysym->sym == SDLK_ESCAPE )

--- a/src/UseState.cpp
+++ b/src/UseState.cpp
@@ -33,7 +33,7 @@ int CUseState::OnHandleKey( SDL_Keysym *keysym )
 int CUseState::OnHandleWield( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling WIELD \n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling WIELD \n" );
     retval = OnBaseHandleKey( keysym, USE_WIELD );
 
     if( retval == JRESETSTATE )
@@ -50,7 +50,7 @@ int CUseState::OnHandleWield( SDL_Keysym *keysym )
     }
 
     // We got a alpha key; do a "wield" of that item
-    JLog( LOG_LEVEL_DEBUG, true, "WIELD got a selection\n" );
+    JLog( LOG_LEVEL_NOISE, true, "WIELD got a selection\n" );
     if( TestWield() )
     {
         if( DoWield() )
@@ -71,7 +71,7 @@ int CUseState::OnHandleWield( SDL_Keysym *keysym )
     }
     m_pSelected = NULL;
 
-    JLog( LOG_LEVEL_INFO, true, "WIELD resetting game state to COMMAND, WIELD state to INIT\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "WIELD resetting game state to COMMAND, WIELD state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
     return 0;
@@ -80,7 +80,7 @@ int CUseState::OnHandleWield( SDL_Keysym *keysym )
 int CUseState::OnHandleRemove( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling REMOVE \n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling REMOVE \n" );
     retval = OnBaseHandleKey( keysym, USE_REMOVE );
 
     if( retval == JRESETSTATE )
@@ -97,7 +97,7 @@ int CUseState::OnHandleRemove( SDL_Keysym *keysym )
     }
 
     // We got a alpha key; do a "remove" of that item
-    JLog( LOG_LEVEL_DEBUG, true, "REMOVE  got a selection\n" );
+    JLog( LOG_LEVEL_NOISE, true, "REMOVE  got a selection\n" );
     if( TestRemove() )
     {
         if( DoRemove() )
@@ -117,7 +117,7 @@ int CUseState::OnHandleRemove( SDL_Keysym *keysym )
                                     m_pSelected->m_lpData->GetName() );
     }
 
-    JLog( LOG_LEVEL_INFO, true, "REMOVE resetting game state to COMMAND, REMOVE state to INIT\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "REMOVE resetting game state to COMMAND, REMOVE state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
     return 0;
@@ -126,7 +126,7 @@ int CUseState::OnHandleRemove( SDL_Keysym *keysym )
 int CUseState::OnHandleDrop( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling DROP \n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling DROP \n" );
     retval = OnBaseHandleKey( keysym, USE_DROP );
 
     if( retval == JRESETSTATE )
@@ -143,7 +143,7 @@ int CUseState::OnHandleDrop( SDL_Keysym *keysym )
     }
 
     // We got a alpha key; do a "drop" of that item
-    JLog( LOG_LEVEL_DEBUG, true, "DROP  got a selection\n" );
+    JLog( LOG_LEVEL_NOISE, true, "DROP  got a selection\n" );
     if( TestDrop() )
     {
         if( DoDrop() )
@@ -164,7 +164,7 @@ int CUseState::OnHandleDrop( SDL_Keysym *keysym )
     }
     m_pSelected = NULL;
 
-    JLog( LOG_LEVEL_INFO, true, "DROP resetting game state to COMMAND, USE state to INIT\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "DROP resetting game state to COMMAND, USE state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
     return 0;
@@ -173,7 +173,7 @@ int CUseState::OnHandleDrop( SDL_Keysym *keysym )
 int CUseState::OnHandleRead( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling READ\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling READ\n" );
     retval = OnBaseHandleKey( keysym, USE_READ );
 
     if( retval == JRESETSTATE )
@@ -188,7 +188,7 @@ int CUseState::OnHandleRead( SDL_Keysym *keysym )
         g_pGame->GetMsgs()->Printf( "Choose an item from inventory(a to z):\n" );
         return 0;
     }
-    JLog( LOG_LEVEL_DEBUG, true, "READ got a selection\n" );
+    JLog( LOG_LEVEL_NOISE, true, "READ got a selection\n" );
     if( TestRead() )
     {
         if( DoRead() )
@@ -203,7 +203,7 @@ int CUseState::OnHandleRead( SDL_Keysym *keysym )
         }
     }
 
-    JLog( LOG_LEVEL_INFO, true, "READ resetting game state to COMMAND, USE state to INIT\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "READ resetting game state to COMMAND, USE state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
     return 0;
@@ -212,7 +212,7 @@ int CUseState::OnHandleRead( SDL_Keysym *keysym )
 int CUseState::OnHandleQuaff( SDL_Keysym *keysym )
 {
     int retval;
-    JLog( LOG_LEVEL_INFO, true, "Handling QUAFF\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Handling QUAFF\n" );
     retval = OnBaseHandleKey( keysym, USE_QUAFF );
 
     if( retval == JRESETSTATE )
@@ -229,7 +229,7 @@ int CUseState::OnHandleQuaff( SDL_Keysym *keysym )
     }
 
     // We got a alpha key; do a "quaff" of that item
-    JLog( LOG_LEVEL_DEBUG, true, "QUAFF  got a selection\n" );
+    JLog( LOG_LEVEL_NOISE, true, "QUAFF  got a selection\n" );
     if( TestQuaff() )
     {
         if( DoQuaff() )
@@ -249,7 +249,7 @@ int CUseState::OnHandleQuaff( SDL_Keysym *keysym )
     }
     m_pSelected = NULL;
 
-    JLog( LOG_LEVEL_INFO, true, "QUAFF resetting game state to COMMAND, USE state to INIT\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "QUAFF resetting game state to COMMAND, USE state to INIT\n" );
     // One way or another, we're done with this state now.
     ResetToState( STATE_COMMAND );
     return 0;
@@ -257,7 +257,7 @@ int CUseState::OnHandleQuaff( SDL_Keysym *keysym )
 
 int CUseState::OnHandleInit( SDL_Keysym *keysym )
 {
-    JLog( LOG_LEVEL_INFO, true, "Initializing USE state...\n" );
+    JLog( LOG_LEVEL_DEBUG, true, "Initializing USE state...\n" );
     if( !m_cCommand )
     {
         m_cCommand = keysym->sym;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -109,22 +109,46 @@ JVector Near( const JVector vOrig, int distance )
 {
     // want an integer position within a certain distance
     // but never the same as the original position
-    int direction = GetRandom(0,7);
+    int direction = GetRandom( 0, 7 );
     int x = 0;
     int y = 0;
 
-    switch(direction)
+    switch( direction )
     {
-        case DIR_NORTH: x = 0; y = 1; break;
-        case DIR_NE:    x = 1; y = 1; break;
-        case DIR_EAST:  x = 1; y = 0; break;
-        case DIR_SE:    x = 1; y = -1; break;
-        case DIR_SOUTH: x = 0; y = -1; break;
-        case DIR_SW:    x = -1; y = -1; break;
-        case DIR_WEST:  x = -1; y = 0; break;
-        case DIR_NW:    x = -1; y = 1; break;
+    case DIR_NORTH:
+        x = 0;
+        y = 1;
+        break;
+    case DIR_NE:
+        x = 1;
+        y = 1;
+        break;
+    case DIR_EAST:
+        x = 1;
+        y = 0;
+        break;
+    case DIR_SE:
+        x = 1;
+        y = -1;
+        break;
+    case DIR_SOUTH:
+        x = 0;
+        y = -1;
+        break;
+    case DIR_SW:
+        x = -1;
+        y = -1;
+        break;
+    case DIR_WEST:
+        x = -1;
+        y = 0;
+        break;
+    case DIR_NW:
+        x = -1;
+        y = 1;
+        break;
     }
-    JVector vDelta( x*GetRandom(1,distance),y*GetRandom(1,distance) );
+    JVector vDelta( x * GetRandom( 1, distance ), y * GetRandom( 1, distance ) );
     return JVector( vOrig + vDelta );
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 
 // The global game pointer
 CGame *g_pGame = NULL;
-eLogLevel g_eLogLevel = LOG_LEVEL_WARN;
+eLogLevel g_eLogLevel = LOG_LEVEL_INFO;
 
 JIVector g_vDirDelta[] = { JIVector( 0, -1 ), JIVector( 0, 1 ), JIVector( -1, 0 ),
                            JIVector( 1, 0 ) };

--- a/test/features/step_definitions/DungeonMapSteps.cpp
+++ b/test/features/step_definitions/DungeonMapSteps.cpp
@@ -136,10 +136,10 @@ THEN( "^The JRect ([0-9.-]+),([0-9.-]+),([0-9.-]+),([0-9.-]+) is now filled with
         {
             JIVector vCheck( x, y );
             int expected = context->map.GetdtdIndex( vCheck );
-            JLog( LOG_LEVEL_DEBUG, true, "<%d %d>: %d/%d ", VEC_EXPAND( vCheck ), expected, type );
+            JLog( LOG_LEVEL_NOISE, true, "<%d %d>: %d/%d ", VEC_EXPAND( vCheck ), expected, type );
             EXPECT_EQ( expected, type );
         }
-        JLog( LOG_LEVEL_DEBUG, true, "\n" );
+        JLog( LOG_LEVEL_NOISE, true, "\n" );
     }
 }
 
@@ -158,10 +158,10 @@ THEN( "^The JRect ([0-9.-]+),([0-9.-]+),([0-9.-]+),([0-9.-]+) is now lit$" )
         {
             JIVector vCheck( x, y );
             int expected = context->map.GetFlags( vCheck );
-            JLog( LOG_LEVEL_DEBUG, true, "<%d %d>: %d/%d ", VEC_EXPAND( vCheck ), expected,
+            JLog( LOG_LEVEL_NOISE, true, "<%d %d>: %d/%d ", VEC_EXPAND( vCheck ), expected,
                   DUNG_FLAG_LIT );
             EXPECT_EQ( expected, DUNG_FLAG_LIT );
         }
-        JLog( LOG_LEVEL_DEBUG, true, "\n" );
+        JLog( LOG_LEVEL_NOISE, true, "\n" );
     }
 }

--- a/test/features/step_definitions/EquipmentSteps.cpp
+++ b/test/features/step_definitions/EquipmentSteps.cpp
@@ -32,12 +32,12 @@ GIVEN( "^I spawn a ([A-Za-z ]+):([0-9]+)$" )
 
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( context->index );
 
-    int compare = strcmp( context->szBuffer, pid->m_szName);
+    int compare = strcmp( context->szBuffer, pid->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", item.c_str(), pid->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
     context->result = CItem::CreateItem( pid, context->vec_b );
 }
 
@@ -47,12 +47,12 @@ GIVEN( "^the player has a ([A-Za-z ]+):([0-9]+) in inventory$" )
     REGEX_PARAM( std::string, item );
     REGEX_PARAM( int, item_id );
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
-    int compare = strcmp( item.c_str(), pid->m_szName);
+    int compare = strcmp( item.c_str(), pid->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", item.c_str(), pid->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
 
     g_pGame->GetPlayer()->PickUp( context->vec_b );
     int inv_index =
@@ -70,12 +70,12 @@ GIVEN( "^the ([A-Za-z ]+):([0-9]+) (is|is not) cursed$" )
     REGEX_PARAM( std::string, choice );
     int chance = ( choice == "is" ) ? 100 : 0;
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
-    int compare = strcmp( item.c_str(), pid->m_szName);
+    int compare = strcmp( item.c_str(), pid->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", item.c_str(), pid->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
     CDungeonTile *pTile = g_pGame->GetDungeon()->GetTile( context->vec_b );
     CItem *pItem = pTile->m_pCurItem;
     pItem->SetCursed( chance );
@@ -94,12 +94,12 @@ GIVEN( "^the player has a ([A-Za-z ]+):([0-9]+) in equipment at ([-0-9]+)$" )
     REGEX_PARAM( int, item_id );
     REGEX_PARAM( int, equip_id );
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
-    int compare = strcmp( item.c_str(), pid->m_szName);
+    int compare = strcmp( item.c_str(), pid->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", item.c_str(), pid->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
     CItem *expected = NULL;
     CItem *actual = g_pGame->GetPlayer()->m_llEquipment->GetLink( equip_id )->m_lpData;
     EXPECT_NE( expected, actual );
@@ -152,12 +152,12 @@ THEN( "^The ([A-Za-z ]+):([0-9]+) is in (inventory|equipment) at ([-0-9]+)$" )
                                                       : g_pGame->GetPlayer()->m_llEquipment;
     CItem *expected = NULL;
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
-    int compare = strcmp( item.c_str(), pid->m_szName);
+    int compare = strcmp( item.c_str(), pid->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", item.c_str(), pid->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
     int item_type = pid->m_dwIndex;
     int equip_slot = EQUIP_IDX_MAIN_HAND + equip_id;
     int index = ( list == "inventory" ) ? item_type : equip_slot;
@@ -186,12 +186,12 @@ THEN( "^The ([A-Za-z ]+):([0-9]+) is not in (inventory|equipment) at ([-0-9]+)$"
                                                       : g_pGame->GetPlayer()->m_llEquipment;
     CItem *expected = NULL;
     CItemDef *pid = g_pGame->GetDungeon()->GetItemDef( item_id );
-    int compare = strcmp( item.c_str(), pid->m_szName);
+    int compare = strcmp( item.c_str(), pid->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n",item.c_str(), pid->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", item.c_str(), pid->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
     int index = ( list == "inventory" ) ? pid->m_dwIndex : equip_id;
     CLink<CItem> *pLink = pList->GetLink( index );
     CItem *actual = NULL;

--- a/test/features/step_definitions/FirstSteps.cpp
+++ b/test/features/step_definitions/FirstSteps.cpp
@@ -3,11 +3,11 @@
 
 using cucumber::ScenarioScope;
 #include "TestContext.hpp"
-AFTER_ALL() { JLog( LOG_LEVEL_INFO, true, "-------------------- (After all scenarios)\n" ); }
+AFTER_ALL() { JLog( LOG_LEVEL_ERROR, true, "-------------------- (After all scenarios)\n" ); }
 AFTER()
 {
     g_pGame = NULL;
-    JLog( LOG_LEVEL_INFO, true, "-------------------- (After each scenario)\n" );
+    JLog( LOG_LEVEL_ERROR, true, "-------------------- (After each scenario)\n" );
 }
 /*#######
 ##

--- a/test/features/step_definitions/FirstSteps.cpp
+++ b/test/features/step_definitions/FirstSteps.cpp
@@ -3,11 +3,11 @@
 
 using cucumber::ScenarioScope;
 #include "TestContext.hpp"
-AFTER_ALL() { JLog( LOG_LEVEL_WARN, true, "-------------------- (After all scenarios)\n" ); }
+AFTER_ALL() { JLog( LOG_LEVEL_INFO, true, "-------------------- (After all scenarios)\n" ); }
 AFTER()
 {
     g_pGame = NULL;
-    JLog( LOG_LEVEL_WARN, true, "-------------------- (After each scenario)\n" );
+    JLog( LOG_LEVEL_INFO, true, "-------------------- (After each scenario)\n" );
 }
 /*#######
 ##

--- a/test/features/step_definitions/GameSteps.cpp
+++ b/test/features/step_definitions/GameSteps.cpp
@@ -33,44 +33,45 @@ GIVEN( "^the game has a player$" )
 }
 GIVEN( "^I spawn a ([-A-Za-z ]+):([0-9]+), a monster with SEEK$" )
 {
-    REGEX_PARAM(std::string, monster);
-    REGEX_PARAM(int, monster_id);
+    REGEX_PARAM( std::string, monster );
+    REGEX_PARAM( int, monster_id );
     ScenarioScope<TestCtx> context;
     context->vec_b.Init( -2, -2 );
     context->vec_b += context->vec;
 
     // Dungeon mangling for test: make sure LZ is clear
-    JVector vLZ(context->vec_b.x, context->vec_b.y);
+    JVector vLZ( context->vec_b.x, context->vec_b.y );
     for( int y = 0; y < 2; y++ )
     {
-        vLZ.y = context->vec_b.y+y;
+        vLZ.y = context->vec_b.y + y;
         for( int x = 0; x < 2; x++ )
         {
-            vLZ.x = context->vec_b.x+x;
-            CDungeonTile *pLZ = g_pGame->GetDungeon()->GetTile(vLZ);
+            vLZ.x = context->vec_b.x + x;
+            CDungeonTile *pLZ = g_pGame->GetDungeon()->GetTile( vLZ );
             pLZ->m_dtd->m_dwType = DUNG_IDX_FLOOR;
         }
     }
 
     int expected = DUNG_COLL_NO_COLLISION;
-    int actual = g_pGame->GetDungeon()->IsWalkableFor(context->vec_b);
+    int actual = g_pGame->GetDungeon()->IsWalkableFor( context->vec_b );
 
-    EXPECT_EQ(expected, actual);
+    EXPECT_EQ( expected, actual );
     // End Dungeon Mangling
 
     CMonsterDef *pmd = g_pGame->GetDungeon()->GetMonsterDef( monster_id );
 
     // Monster is correct monster
-    int compare = strcmp(monster.c_str(), pmd->m_szName);
+    int compare = strcmp( monster.c_str(), pmd->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pmd->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pmd->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
 
     context->result = CMonster::CreateMonster( pmd, context->vec_b );
 
-    JLog( LOG_LEVEL_ERROR, true, "<%f %f> %s %d\n", VEC_EXPAND( context->vec_b ), pmd->m_szName, context->result );
+    JLog( LOG_LEVEL_ERROR, true, "<%f %f> %s %d\n", VEC_EXPAND( context->vec_b ), pmd->m_szName,
+          context->result );
 }
 GIVEN( "^I update the monster's brain$" )
 {
@@ -109,37 +110,37 @@ THEN( "^the game terminates successfully$" ) { EXPECT_EQ( true, true ); }
 
 THEN( "^the ([-A-Za-z ]+) spawned successfully$" )
 {
-    REGEX_PARAM(std::string, monster);
+    REGEX_PARAM( std::string, monster );
     ScenarioScope<TestCtx> context;
     int actual = context->result;
     EXPECT_EQ( actual, JSUCCESS );
     CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
 
     // Monster is correct monster
-    int compare = strcmp(monster.c_str(), pMon->m_md->m_szName);
+    int compare = strcmp( monster.c_str(), pMon->m_md->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
 }
 
 THEN( "^the ([-A-Za-z ]+) wants to move toward the player$" )
 {
-    REGEX_PARAM(std::string, monster);
+    REGEX_PARAM( std::string, monster );
     ScenarioScope<TestCtx> context;
     CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
 
     // Monster is correct monster
-    int compare = strcmp(monster.c_str(), pMon->m_md->m_szName);
+    int compare = strcmp( monster.c_str(), pMon->m_md->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
 
     // Monster wants to move toward player
-    JLog(LOG_LEVEL_ERROR, false, "heading <%.2f %.2f>\n", VEC_EXPAND(pMon->m_pBrain->m_vVel));
+    JLog( LOG_LEVEL_ERROR, false, "heading <%.2f %.2f>\n", VEC_EXPAND( pMon->m_pBrain->m_vVel ) );
     JVector expected( 1.0f, 1.0f );
     JVector actual = pMon->m_pBrain->m_vVel;
     EXPECT_EQ( expected.x, actual.x );
@@ -150,7 +151,7 @@ THEN( "^the ([-A-Za-z ]+) wants to move toward the player$" )
 
 THEN( "^the ([-A-Za-z ]+) moves toward the player$" )
 {
-    REGEX_PARAM(std::string, monster);
+    REGEX_PARAM( std::string, monster );
     ScenarioScope<TestCtx> context;
     // Monster not in old pos
     CMonster *pMon = g_pGame->GetDungeon()->GetTile( context->vec_b )->m_pCurMonster;
@@ -166,10 +167,10 @@ THEN( "^the ([-A-Za-z ]+) moves toward the player$" )
     EXPECT_EQ( expected, true );
 
     // Monster is correct monster
-    int compare = strcmp(monster.c_str(), pMon->m_md->m_szName);
+    int compare = strcmp( monster.c_str(), pMon->m_md->m_szName );
     if( compare != 0 )
     {
-        JLog(LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName);
+        JLog( LOG_LEVEL_ERROR, true, "want %s have %s\n", monster.c_str(), pMon->m_md->m_szName );
     }
-    EXPECT_EQ(compare, 0);
+    EXPECT_EQ( compare, 0 );
 }

--- a/test/features/step_definitions/MonsterSteps.cpp
+++ b/test/features/step_definitions/MonsterSteps.cpp
@@ -66,7 +66,7 @@ THEN( "^I can see all the monster names$" )
     CLink<CMonster> *pLink = context->m_llMonsters->GetHead();
     while( pLink != NULL )
     {
-        JLog( LOG_LEVEL_DEBUG, true, "Monster is %s\n", pLink->m_lpData->GetName() );
+        JLog( LOG_LEVEL_WARN, true, "Monster is %s\n", pLink->m_lpData->GetName() );
         pLink = context->m_llMonsters->GetNext( pLink );
     }
 }

--- a/test/features/step_definitions/MonsterSteps.cpp
+++ b/test/features/step_definitions/MonsterSteps.cpp
@@ -66,7 +66,7 @@ THEN( "^I can see all the monster names$" )
     CLink<CMonster> *pLink = context->m_llMonsters->GetHead();
     while( pLink != NULL )
     {
-        JLog( LOG_LEVEL_INFO, true, "Monster is %s\n", pLink->m_lpData->GetName() );
+        JLog( LOG_LEVEL_DEBUG, true, "Monster is %s\n", pLink->m_lpData->GetName() );
         pLink = context->m_llMonsters->GetNext( pLink );
     }
 }


### PR DESCRIPTION
logs were so noisy that I had to leave players at WARN and tests at ERROR. 
* I added LOG_LEVEL_NOISE to take the crazy loud stuff, 
* moved all the INFO to DEBUG, 
* moved all the WARN to INFO, and 
* then reset the WARN to actual warnings 
* (left errors alone, they were already "real errors").  

As a side effect of all this, I noticed that equipment was displaying as "a, g, i" but being read as "a,b,c" -- this was an error in JLinkList::GetLink(), where it was not taking an early-out if the desired link is found (found by comparing the desired index with the current index, not by just counting links until you get there).

* equipment now honors equip slots