### PR TITLE
moved door creation into CreateOneStep

### DIFF
--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -846,8 +846,8 @@ JResult CDungeon::Modify( JVector &vPos )
     if( GetTile( vPos )->m_dtd->m_dwModifiedType == DUNG_IDX_INVALID )
     {
         // hey! you can't modify that tile! How did you get here?!
-        JLog( LOG_LEVEL_ERROR, true, "Modify error: Can't modify type %d at <%f %f> with type %s\n",
-              GetTile( vPos )->m_dtd->m_dwType, VEC_EXPAND( vPos ) );
+        JLog( LOG_LEVEL_ERROR, true, "Modify error: Can't modify type %d at <%f %f>\n",
+              GetTile( vPos )->m_dtd->m_dwType, VEC_EXPAND( vPos ));
         return JERROR();
     }
 

--- a/src/DungeonMap.cpp
+++ b/src/DungeonMap.cpp
@@ -156,34 +156,7 @@ void TweakBorders( JRect &rcIn, int direction )
 
 bool CDungeonMap::CheckBorder( const JRect area, int direction )
 {
-    JRect rcCheck( area );
-    // TweakBorders(rcCheck, direction);
-    if( rcCheck.top <= 0 )
-    {
-        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, top=0\n",
-              RECT_EXPAND( rcCheck ) );
-        return false;
-    }
-    else if( rcCheck.bottom >= DUNG_HEIGHT - 1 )
-    {
-        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, bottom=max\n",
-              RECT_EXPAND( rcCheck ) );
-        return false;
-    }
-    else if( rcCheck.left <= 0 )
-    {
-        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, left=0\n",
-              RECT_EXPAND( rcCheck ) );
-        return false;
-    }
-    else if( rcCheck.right >= DUNG_WIDTH - 1 )
-    {
-        JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, right=max\n",
-              RECT_EXPAND( rcCheck ) );
-        return false;
-    }
-
-    JRect rcEdges( rcCheck.left - 1, rcCheck.top - 1, rcCheck.right + 1, rcCheck.bottom + 1 );
+    JRect rcEdges( area.left - 1, area.top - 1, area.right + 1, area.bottom + 1 );
     if( !rcEdges.IsInWorld() )
     {
         JLog( LOG_LEVEL_NOISE, true, "border failed: <%d %d, %d %d>, edges fail.\n",
@@ -202,7 +175,8 @@ bool CDungeonMap::CheckBorder( const JRect area, int direction )
             {
                 JLog( LOG_LEVEL_NOISE, true,
                       "border check failed. Wanted <%d %d, %d %d>, but <%d %d> was %d\n",
-                      RECT_EXPAND( area ), x, y, m_dmtTiles[y * DUNG_WIDTH + x].GetType() );
+                      RECT_EXPAND( area ), VEC_EXPAND( vCheck ), GetTile( vCheck )->GetType() );
+                // TODO: ... what if we allow overlaps? This is just a border check... the interior is OK.
                 return false;
             }
         }
@@ -397,7 +371,10 @@ bool CDungeonMap::CreateOneStep()
                 continue;
             pNewStep = MakeHallStep( vHall, dir, pCurStep->m_dwRecurDepth + 1 );
             if( pNewStep != NULL )
+            {
+                AddDoor(vHall, dir);
                 m_stkDungeonMapCreation->Push( pNewStep );
+            }
         }
     }
     break;
@@ -409,12 +386,14 @@ bool CDungeonMap::CreateOneStep()
             // Make a (single) room, in the direction of this hallway
             int dir = pCurStep->m_dwDirection;
             JIVector vRoom = GetHallOrigin( pCurStep, DUNG_CREATE_STEP_MAKE_ROOM );
-            AddDoor( vRoom, dir );
             if( !vRoom.IsWithinWorld() )
                 break;
             pNewStep = MakeRoomStep( vRoom, dir, pCurStep->m_dwRecurDepth + 1 );
             if( pNewStep != NULL )
+            {
+                AddDoor(vRoom, dir);
                 m_stkDungeonMapCreation->Push( pNewStep );
+            }
         }
         else if( pick_next <= 100 )
         {
@@ -441,7 +420,10 @@ bool CDungeonMap::CreateOneStep()
                     break;
                 pNewStep = MakeHallStep( vHall, dir, pCurStep->m_dwRecurDepth + 1 );
                 if( pNewStep != NULL )
+                {
+                    AddDoor(vHall, pCurStep->m_dwDirection);
                     m_stkDungeonMapCreation->Push( pNewStep );
+                }
             }
         }
     }
@@ -519,7 +501,7 @@ CDungeonCreationStep *CDungeonMap::MakeRoomStep( const JIVector &vPos, const int
 {
     if( recurdepth > MAX_RECURDEPTH )
         return NULL;
-    JLog( LOG_LEVEL_WARN, true, "Creating a room step\n" );
+    JLog( LOG_LEVEL_INFO, true, "Creating a room step\n" );
     CDungeonCreationStep *pStep = new CDungeonCreationStep();
     pStep->m_dwIndex = DUNG_CREATE_STEP_MAKE_ROOM;
     pStep->m_dwDirection = direction;
@@ -558,10 +540,10 @@ CDungeonCreationStep *CDungeonMap::MakeRoomStep( const JIVector &vPos, const int
         return NULL;
     }
     // put a door where the room and hallway meet
-    if( recurdepth > 0 )
-        AddDoor( pStep->m_vPos, pStep->m_dwDirection );
+    // if( recurdepth > 0 )
+    //     AddDoor( pStep->m_vPos, pStep->m_dwDirection );
 
-    JLog( LOG_LEVEL_WARN, true, "success!\n" );
+    JLog( LOG_LEVEL_INFO, true, "success!\n" );
     return pStep;
 }
 
@@ -570,6 +552,7 @@ CDungeonCreationStep *CDungeonMap::MakeHallStep( const JIVector &vPos, const int
 {
     if( recurdepth > MAX_RECURDEPTH )
         return NULL;
+    JLog( LOG_LEVEL_INFO, true, "Creating a hall step\n" );
     CDungeonCreationStep *pStep = new CDungeonCreationStep();
     pStep->m_dwIndex = DUNG_CREATE_STEP_MAKE_HALLWAY;
     pStep->m_dwRecurDepth = recurdepth;
@@ -606,8 +589,9 @@ CDungeonCreationStep *CDungeonMap::MakeHallStep( const JIVector &vPos, const int
         return NULL;
     }
     // put a door where the room and hallway meet
-    AddDoor( pStep->m_vPos, pStep->m_dwDirection );
+    // AddDoor( pStep->m_vPos, pStep->m_dwDirection );
 
+    JLog( LOG_LEVEL_INFO, true, "success!\n" );
     return pStep;
 }
 

--- a/test/features/dungeonmap.feature
+++ b/test/features/dungeonmap.feature
@@ -137,3 +137,10 @@ Feature: Dungeon Creation
         Then The JRect 1,1,5,1 is now filled with 0
         Then The JRect 0,0,6,2 is now lit
         And The rect is in world
+
+    Scenario: I can create rooms and hallways using steps
+        Given I have a DungeonMap
+        Given I have a room create step
+        Given I have a E hallway create step
+        When I create a S hallway create step
+        Then the S hallway meets the E hallway

--- a/test/features/step_definitions/DungeonMapSteps.cpp
+++ b/test/features/step_definitions/DungeonMapSteps.cpp
@@ -36,11 +36,38 @@ GIVEN( "^I have a JRect ([0-9.-]+),([0-9.-]+),([0-9.-]+),([0-9.-]+) to fill$" )
     context->area = JRect( l, t, r, b );
 }
 
+GIVEN("^I have a room create step$")
+{
+    ScenarioScope<TestCtx> context;
+    JIVector vRoom(50,50);
+    context->pStep = context->map.MakeRoomStep(vRoom,DIR_NONE,0);
+
+    JLog(LOG_LEVEL_ERROR, false, "room: <%d %d %d %d>\n", RECT_EXPAND(context->pStep->m_rcArea));
+}
+
+GIVEN("^I have a E hallway create step$")
+{
+    ScenarioScope<TestCtx> context;
+    JIVector vHallway = context->map.GetWallOrigin(context->pStep, DIR_EAST);
+    context->pStep = context->map.MakeHallStep(vHallway,DIR_EAST,1);
+    context->area.Init(context->pStep->m_rcArea);
+    JLog(LOG_LEVEL_ERROR, false, "E hallway: <%d %d %d %d>\n", RECT_EXPAND(context->area));
+}
+
 /*#######
 ##
 ## WHEN
 ##
 #######*/
+WHEN("^I create a S hallway create step$")
+{
+    ScenarioScope<TestCtx> context;
+    context->vec_i = context->map.GetHallOrigin(context->pStep, DUNG_CREATE_STEP_MAKE_HALLWAY);
+    context->pStep = context->map.MakeHallStep(context->vec_i,DIR_SOUTH,2);
+
+    JLog(LOG_LEVEL_ERROR, false, "S origin: <%d %d>\n", VEC_EXPAND(context->vec_i));
+}
+
 WHEN( "^I call GetHallRect for east from ([0-9.-]+),([0-9.-]+)$" )
 {
     REGEX_PARAM( int, x );
@@ -119,6 +146,19 @@ WHEN( "^I call FillArea for a hallway east$" )
 ## THEN
 ##
 #######*/
+
+THEN("^the S hallway meets the E hallway$")
+{
+    ScenarioScope<TestCtx> context;
+    JRect s(context->vec_i,0,0);
+    JRect e(context->area);
+
+    // New Hallway should start +1 in the direction of the last hallway
+    JIVector vEast(e.right+1, e.top);
+
+    EXPECT_EQ(context->vec_i.x, vEast.x);
+    EXPECT_EQ(context->vec_i.y, vEast.y);
+}
 
 THEN( "^The JRect ([0-9.-]+),([0-9.-]+),([0-9.-]+),([0-9.-]+) is now filled with ([0-9]+)$" )
 {

--- a/test/features/step_definitions/TestContext.hpp
+++ b/test/features/step_definitions/TestContext.hpp
@@ -28,6 +28,7 @@ struct TestCtx
 {
     JVector vec;
     JVector vec_b;
+    JIVector vec_i;
 
     JRect area;
 
@@ -45,6 +46,7 @@ struct TestCtx
 
     // DungeonMap
     CDungeonMap map;
+    CDungeonCreationStep *pStep;
 
     // AI Brain
     CAIBrain *brain;


### PR DESCRIPTION
This is an attempt to get hallways to "link up" with each other -- I hardly ever see long hallways in the current build algorithm. 

Two known problems:
* edge checking will "fail" if a hallway extends into an existing room or hallway (this should be allowed)
* many "off by one" or "off by two" errors -- two lit hallways terminating next to each other, or "looks like a secret door" -- but isn't.