### PR TITLE
fix: line of sight

### DIFF
--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -572,7 +572,6 @@ bool CDungeon::WithinSight( JVector vCheck )
             vPos.y += vStep.y;
         }
     }
-    g_pGame->GetPlayer()->m_bIsDisturbed = true;
     return true;
 }
 
@@ -664,6 +663,8 @@ void CDungeon::DrawDungeon()
         }
     }
 }
+
+void CDungeon::DisturbPlayer() { g_pGame->GetPlayer()->m_bIsDisturbed = true; }
 
 void CDungeon::DrawItems()
 {

--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -652,8 +652,9 @@ void CDungeon::DrawDungeon()
             // this tile doesn't exist, or it's not been seen
             // or something else is standing there
             if( curTile == NULL || ( ( curTile->m_dwFlags & DUNG_FLAG_SEEN ) == 0 ) ||
-                vScreen == vPlayer || curTile->m_pCurItem != NULL ||
-                curTile->m_pCurMonster != NULL )
+                vScreen == vPlayer ||
+                ( WithinSight( vScreen ) &&
+                  ( curTile->m_pCurItem != NULL || curTile->m_pCurMonster != NULL ) ) )
             {
                 continue;
             }

--- a/src/Dungeon.h
+++ b/src/Dungeon.h
@@ -81,6 +81,7 @@ public:
     JResult UpdateSeen();
     void LightRoom( CRoom *pRoom );
     bool WithinSight( JVector vCheck );
+    void DisturbPlayer();
 
     JResult OnChangeLevel( const int delta );
 

--- a/src/DungeonMap.h
+++ b/src/DungeonMap.h
@@ -206,8 +206,8 @@ public:
         {
             if( pLink->m_lpData->GetArea().Contains( vCheck ) )
             {
-                JLog( LOG_LEVEL_DEBUG, true, "Inside room: <%d %d %d %d>\n",
-                      RECT_EXPAND( pLink->m_lpData->GetEdges() ) );
+                JLog( LOG_LEVEL_DEBUG, true, "<%d %d> Inside room: <%d %d %d %d>\n",
+                      VEC_EXPAND( vCheck ), RECT_EXPAND( pLink->m_lpData->GetArea() ) );
                 return pLink->m_lpData;
             }
             pLink = m_llRooms->GetNext( pLink );

--- a/src/JRect.h
+++ b/src/JRect.h
@@ -123,7 +123,7 @@ public:
 
     bool Contains( const JIVector vTarget )
     {
-        if( vTarget.x < left || vTarget.x >= right || vTarget.y < top || vTarget.y >= bottom )
+        if( vTarget.x < left || vTarget.x > right || vTarget.y < top || vTarget.y > bottom )
         {
             return false;
         }

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -327,6 +327,8 @@ void CMonster::Draw()
         return;
     }
 
+    g_pGame->GetDungeon()->DisturbPlayer();
+
     Uint8 monster_tile = MonIDs[m_md->m_dwIndex] - ' ' - 1;
     JVector DUNG_ASPECT;
 


### PR DESCRIPTION
* tiles with monsters/items on them are restricted to WithinSight
* player disturb (turns off run and rest) happens during monster::draw (where withinsight is called), not withinsight (which is also used for other stuff)
* boundary bug in Util::Contains was affecting both WithinSight and InRoom