### PR TITLE
fix: Breed line-of-sight

### DIFF
--- a/src/AIMgr.cpp
+++ b/src/AIMgr.cpp
@@ -73,6 +73,14 @@ bool CAIBrain::Update( float fCurTime )
         break;
     }
 
+    if( !g_pGame->GetPlayer()->m_bIsDisturbed )
+    {
+        if( g_pGame->GetDungeon()->CanSeePlayer( m_vPos ) )
+        {
+            g_pGame->GetDungeon()->DisturbPlayer();
+        }
+    }
+
     return false;
 }
 

--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -497,8 +497,9 @@ JResult CDungeon::UpdateSeen()
         {
             GetITile( vTile )->SetFlags( DUNG_FLAG_SEEN );
             pRoom = m_dmCurLevel->InRoom( vTile );
-            if( pRoom != NULL && pRoom->HasFlags( DUNG_FLAG_LIT ) &&
-                !pRoom->HasFlags( DUNG_FLAG_SEEN ) )
+            if( pRoom != NULL &&
+                ( g_pGame->GetPlayer()->IsWizard() ||
+                  ( pRoom->HasFlags( DUNG_FLAG_LIT ) && !pRoom->HasFlags( DUNG_FLAG_SEEN ) ) ) )
             {
                 LightRoom( pRoom );
             }
@@ -573,13 +574,16 @@ bool CDungeon::CanSeeEachOther( JIVector vSource, JIVector vTarget )
     return true;
 }
 
-bool CDungeon::WithinSight( JVector vCheck )
+bool CDungeon::CanSeePlayer( JVector vCheck )
 {
-    // Check for sight distance first
-    JIVector vPos( VEC_EXPAND( vCheck ) );
-    JIVector vPlayer( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos ) );
+    if( g_pGame->GetPlayer()->IsWizard() )
+        return true;
 
-    return CanSeeEachOther( vPlayer, vPos );
+    // Check for sight distance first
+    JIVector viCheck( VEC_EXPAND( vCheck ) );
+    JIVector viPlayer( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos ) );
+
+    return CanSeeEachOther( viCheck, viPlayer );
 }
 
 bool CDungeon::IsOnScreen( JVector vPos )
@@ -658,8 +662,10 @@ void CDungeon::DrawDungeon()
             // this tile doesn't exist, or it's not been seen
             // or something else is standing there
             if( curTile == NULL || ( ( curTile->m_dwFlags & DUNG_FLAG_SEEN ) == 0 ) ||
+                ( g_pGame->GetPlayer()->IsWizard() &&
+                  ( curTile->m_dwFlags & ( DUNG_FLAG_SEEN | DUNG_FLAG_LIT ) ) == 0 ) ||
                 vScreen == vPlayer ||
-                ( WithinSight( vScreen ) &&
+                ( CanSeePlayer( vScreen ) &&
                   ( curTile->m_pCurItem != NULL || curTile->m_pCurMonster != NULL ) ) )
             {
                 continue;
@@ -681,7 +687,7 @@ void CDungeon::DrawItems()
     while( pLink != NULL )
     {
         pItem = pLink->m_lpData;
-        if( pItem && IsOnScreen( pItem->m_vPos ) )
+        if( pItem && IsOnScreen( pItem->m_vPos ) && CanSeePlayer( pItem->m_vPos ) )
         {
             pItem->Draw();
         }
@@ -697,7 +703,7 @@ void CDungeon::DrawMonsters()
     while( pLink != NULL )
     {
         pMon = pLink->m_lpData;
-        if( pMon && IsOnScreen( pMon->GetPos() ) )
+        if( pMon && IsOnScreen( pMon->GetPos() ) && CanSeePlayer( pMon->GetPos() ) )
         {
             pMon->Draw();
         }

--- a/src/Dungeon.cpp
+++ b/src/Dungeon.cpp
@@ -522,21 +522,17 @@ void CDungeon::LightRoom( CRoom *pRoom )
     pRoom->SetFlags( DUNG_FLAG_SEEN );
 }
 
-bool CDungeon::WithinSight( JVector vCheck )
+bool CDungeon::CanSeeEachOther( JIVector vSource, JIVector vTarget )
 {
-    // Check for sight distance first
-    JIVector vPos( VEC_EXPAND( vCheck ) );
-    JIVector vPlayer( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos ) );
-
     // can see things in the same room, if the room is LIT
-    CRoom *prCheck = m_dmCurLevel->InRoom( vPos );
-    CRoom *prPlayer = m_dmCurLevel->InRoom( vPlayer );
-    if( prCheck && prCheck->HasFlags( DUNG_FLAG_SEEN ) && prCheck == prPlayer )
+    CRoom *prTarget = m_dmCurLevel->InRoom( vTarget );
+    CRoom *prSource = m_dmCurLevel->InRoom( vSource );
+    if( prTarget && prTarget->HasFlags( DUNG_FLAG_SEEN ) && prTarget == prSource )
         return true;
 
-    JRect rcVisible = Util::Nearby( vPlayer, PLAYER_SIGHT_DISTANCE );
+    JRect rcVisible = Util::Nearby( vSource, PLAYER_SIGHT_DISTANCE );
 
-    if( !rcVisible.Contains( vPos ) )
+    if( !rcVisible.Contains( vTarget ) )
         return false;
 
     // Check along the line between the player and the position
@@ -544,17 +540,19 @@ bool CDungeon::WithinSight( JVector vCheck )
     // Bresenham Line Algorithm
     // TODO: move this somewhere to be used for ranged and magic targeting
     JLinkList<JIVector> *pLine = new JLinkList<JIVector>;
-    JIVector vDelta( abs( vPos.x - vPlayer.x ), abs( vPos.y - vPlayer.y ) );
-    JIVector vStep( vPos.x < vPlayer.x ? 1 : -1, vPos.y < vPlayer.y ? 1 : -1 );
+    JIVector vDelta( abs( vTarget.x - vSource.x ), abs( vTarget.y - vSource.y ) );
+    JIVector vStep( vSource.x < vTarget.x ? 1 : -1, vSource.y < vTarget.y ? 1 : -1 );
     int error = vDelta.x - vDelta.y;
     int errorx2;
 
-    while( vPos.x != vPlayer.x || vPos.y != vPlayer.y )
+    JVector vTest;
+    JIVector vCurrent = vSource;
+    while( vCurrent.x != vTarget.x || vCurrent.y != vTarget.y )
     {
-        JVector vCurrent( VEC_EXPAND( vPos ) );
-        if( vCurrent != vCheck )
+        if( vCurrent != vSource )
         {
-            int collide_type = g_pGame->GetDungeon()->IsWalkableFor( vCurrent );
+            vTest.Init( VEC_EXPAND( vTarget ) );
+            int collide_type = g_pGame->GetDungeon()->IsWalkableFor( vTest );
             if( collide_type != DUNG_COLL_NO_COLLISION )
             {
                 return false;
@@ -564,15 +562,24 @@ bool CDungeon::WithinSight( JVector vCheck )
         if( errorx2 > -vDelta.y )
         {
             error -= vDelta.y;
-            vPos.x += vStep.x;
+            vCurrent.x += vStep.x;
         }
         if( errorx2 < vDelta.x )
         {
             error += vDelta.x;
-            vPos.y += vStep.y;
+            vCurrent.y += vStep.y;
         }
     }
     return true;
+}
+
+bool CDungeon::WithinSight( JVector vCheck )
+{
+    // Check for sight distance first
+    JIVector vPos( VEC_EXPAND( vCheck ) );
+    JIVector vPlayer( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos ) );
+
+    return CanSeeEachOther( vPlayer, vPos );
 }
 
 bool CDungeon::IsOnScreen( JVector vPos )

--- a/src/Dungeon.h
+++ b/src/Dungeon.h
@@ -80,6 +80,7 @@ public:
     bool Update( float fCurTime );
     JResult UpdateSeen();
     void LightRoom( CRoom *pRoom );
+    bool CanSeeEachOther( JIVector vSource, JIVector vTarget );
     bool WithinSight( JVector vCheck );
     void DisturbPlayer();
 

--- a/src/Dungeon.h
+++ b/src/Dungeon.h
@@ -81,7 +81,7 @@ public:
     JResult UpdateSeen();
     void LightRoom( CRoom *pRoom );
     bool CanSeeEachOther( JIVector vSource, JIVector vTarget );
-    bool WithinSight( JVector vCheck );
+    bool CanSeePlayer( JVector vCheck );
     void DisturbPlayer();
 
     JResult OnChangeLevel( const int delta );

--- a/src/EndGameState.cpp
+++ b/src/EndGameState.cpp
@@ -184,9 +184,12 @@ bool CEndGameState::InitScores()
 {
     // call FileParse::Append to add new score (to end of file)
     CDataFile dfScores;
-    dfScores.Append( "Resources/Scores.txt" );
-    dfScores.WriteScore( m_pScore );
-    dfScores.Close();
+    if( m_pScore->m_dwScore > 0 )
+    {
+        dfScores.Append( "Resources/Scores.txt" );
+        dfScores.WriteScore( m_pScore );
+        dfScores.Close();
+    }
 
     // Score entry should have:
     // Player name

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -117,6 +117,16 @@ bool CItem::Update( float fCurTime )
     {
         m_fColorChangeInterval += fCurTime;
     }
+
+    if( !g_pGame->GetPlayer()->m_bIsDisturbed )
+    {
+        JIVector vItem( VEC_EXPAND( m_vPos ) );
+        JIVector vPlayer( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos ) );
+        if( Util::Nearby( vItem, 1 ).Contains( vPlayer ) )
+        {
+            g_pGame->GetDungeon()->DisturbPlayer();
+        }
+    }
     return true;
 }
 
@@ -154,9 +164,9 @@ int CItem::EquipType()
 }
 void CItem::Draw()
 {
-    // Don't draw if something else is there, or if it's out of sight.
+    // Don't draw if something else is there.
     if( g_pGame->GetDungeon()->GetTile( m_vPos )->m_pCurMonster != NULL ||
-        g_pGame->GetPlayer()->m_vPos == m_vPos || !g_pGame->GetDungeon()->WithinSight( m_vPos ) )
+        g_pGame->GetPlayer()->m_vPos == m_vPos )
     {
         return;
     }

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -134,7 +134,10 @@ JIVector CMonster::GetSpawnPoint( JIVector vRequestedSpawnPoint )
         JLog( LOG_LEVEL_INFO, false, "." );
 
         JVector vTryIt( VEC_EXPAND( vTryPos ) );
-        if( g_pGame->GetDungeon()->IsWalkableFor( vTryIt ) == DUNG_COLL_NO_COLLISION )
+        // target spawn point must be walkable and also within sight of the parent (no spawning past
+        // walls or doors!)
+        if( g_pGame->GetDungeon()->IsWalkableFor( vTryIt ) == DUNG_COLL_NO_COLLISION &&
+            ( !bNear || g_pGame->GetDungeon()->CanSeeEachOther( vRequestedSpawnPoint, vTryPos ) ) )
         {
             return vTryPos;
         }

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -324,14 +324,6 @@ void CMonster::SetColor()
 unsigned char MonIDs[MON_IDX_MAX + 1] = "abcddefghhikllmnoprsuwxyzABCDFFFGGHIJKLOPRSTUVWWXY&.,$t";
 void CMonster::Draw()
 {
-    // Don't draw if out of sight.
-    if( !g_pGame->GetDungeon()->WithinSight( GetPos() ) )
-    {
-        return;
-    }
-
-    g_pGame->GetDungeon()->DisturbPlayer();
-
     Uint8 monster_tile = MonIDs[m_md->m_dwIndex] - ' ' - 1;
     JVector DUNG_ASPECT;
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -58,11 +58,42 @@ bool CPlayer::Update( float fCurTime )
         }
         m_fLastLightTime = (float)g_pGame->GetTime();
     }
-    m_bIsDisturbed = false;
+    CheckDisturbance();
     DisplayStats();
     DisplayInventory( PLACEMENT_INV );
     DisplayEquipment( PLACEMENT_EQUIP );
     return true;
+}
+
+void CPlayer::CheckDisturbance()
+{
+    JIVector vPlayer( VEC_EXPAND( m_vPos ) );
+    JRect rcCheck = Util::Nearby( vPlayer, 1 );
+
+    JIVector vCheck;
+    CDungeonTile *pTile;
+    for( vCheck.y = rcCheck.top; vCheck.y <= rcCheck.bottom; vCheck.y++ )
+    {
+        for( vCheck.x = rcCheck.left; vCheck.x <= rcCheck.right; vCheck.x++ )
+        {
+            pTile = g_pGame->GetDungeon()->GetITile( vCheck );
+            // check for interesting dungeon types
+            switch( pTile->m_dtd->m_dwType )
+            {
+            case DUNG_IDX_DOOR:
+            case DUNG_IDX_OPEN_DOOR:
+            case DUNG_IDX_DOWNSTAIRS:
+            case DUNG_IDX_LONG_DOWNSTAIRS:
+            case DUNG_IDX_UPSTAIRS:
+            case DUNG_IDX_LONG_UPSTAIRS:
+            case DUNG_IDX_RUBBLE:
+                m_bIsDisturbed = true;
+                return;
+            }
+            // items and monsters already tag themselves as disturbing
+            // TODO: traps, altars, water,...
+        }
+    }
 }
 
 void CPlayer::Draw()
@@ -459,6 +490,8 @@ int CPlayer::TakeDamage( float fDamage, char *szMon )
         m_fCurHitPoints -= fDamage;
         m_bIsDisturbed = true;
         retval = STATUS_ALIVE;
+
+        JLog( LOG_LEVEL_INFO, true, "Remaining HP: %.2f \n", m_fCurHitPoints );
     }
     else
     {
@@ -469,13 +502,10 @@ int CPlayer::TakeDamage( float fDamage, char *szMon )
         strcpy( m_szKilledBy, szMon );
         // This is the end of the game; make the game end on next update.
         JLog( LOG_LEVEL_INFO, true,
-              "%s died on dungeon level %d, while level %d, killed by a %s.\n", m_szName,
+              "\n\n%s died on dungeon level %d, while level %d, killed by a %s.\n\n", m_szName,
               g_pGame->GetDungeon()->depth, (int)m_fLevel, m_szKilledBy );
         g_pGame->SetState( STATE_ENDGAME );
     }
-
-    JLog( LOG_LEVEL_INFO, true, "Remaining HP: %.2f \n", m_fCurHitPoints );
-
     return retval;
 }
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -139,6 +139,7 @@ public:
     CRace *GetRace() { return m_pRace; }
     float GetExperience() { return m_fExperience; }
     bool Update( float fCurTime );
+    void CheckDisturbance();
     void PreDraw();
     void Draw();
     void PostDraw();

--- a/src/RestState.cpp
+++ b/src/RestState.cpp
@@ -68,6 +68,8 @@ int CRestState::OnHandleInit( SDL_Keysym *keysym )
 {
     JLog( LOG_LEVEL_DEBUG, true, "Initializing REST state...\n" );
 
+    g_pGame->GetPlayer()->m_bIsDisturbed = false;
+
     DoTick();
     m_eCurModifier = REST_TICK;
     m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
@@ -102,6 +104,7 @@ bool CRestState::DoTick()
     if( g_pGame->GetPlayer()->m_bIsRested || g_pGame->GetPlayer()->m_bIsDisturbed )
     {
         JLog( LOG_LEVEL_DEBUG, true, "REST state complete, reset to CMD state.\n" );
+        g_pGame->GetDungeon()->DisturbPlayer();
         ResetToState( STATE_COMMAND );
     }
     g_pGame->SetReadyForUpdate( true );

--- a/src/RunState.cpp
+++ b/src/RunState.cpp
@@ -68,6 +68,7 @@ int CRunState::OnHandleInit( SDL_Keysym *keysym )
 {
     JLog( LOG_LEVEL_DEBUG, true, "Initializing RUN state...\n" );
 
+    g_pGame->GetPlayer()->m_bIsDisturbed = false;
     DoTick();
     m_eCurModifier = RUN_TICK;
     m_pCurKeyHandler = m_pKeyHandlers[m_eCurModifier];
@@ -92,22 +93,17 @@ bool CRunState::DoTick()
 {
     m_dwClock++;
 
-    if( g_pGame->GetPlayer()->Move( g_pGame->GetPlayer()->m_vVel ) == DUNG_COLL_NO_COLLISION )
-    {
-        JLog( LOG_LEVEL_NOISE, true, "RUN state continuing.\n" );
-    }
-    else
+    if( g_pGame->GetPlayer()->m_bIsDisturbed ||
+        g_pGame->GetPlayer()->Move( g_pGame->GetPlayer()->m_vVel ) != DUNG_COLL_NO_COLLISION )
     {
         JLog( LOG_LEVEL_DEBUG, true, "RUN state collided, reset to CMD state.\n" );
-        g_pGame->GetPlayer()->m_bIsDisturbed = true;
+        g_pGame->GetDungeon()->DisturbPlayer();
         g_pGame->GetPlayer()->m_vVel.Init( 0, 0 );
         ResetToState( STATE_COMMAND );
     }
-
-    if( g_pGame->GetPlayer()->m_bIsDisturbed )
+    else
     {
-        JLog( LOG_LEVEL_DEBUG, true, "RUN state complete, reset to CMD state.\n" );
-        ResetToState( STATE_COMMAND );
+        JLog( LOG_LEVEL_NOISE, true, "RUN state continuing.\n" );
     }
 
     g_pGame->SetReadyForUpdate( true );


### PR DESCRIPTION
* items and monsters will not draw if not in sight of player
* wizard mode makes all items, all monsters visible, and lights all rooms when entered
* scores of 0 are not recorded
* monsters will only breed to nearby spawn points they can see (no spawning past closed doors)
* rest and run modes are interrupted when an item, monster, or interesting dungeon feature is within sight