### PR TITLE
feat: Item colors

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -367,6 +367,9 @@
 #define MON_AI 7
 #define EFFECT_TYPE 8
 
+#define NUM_POTION_NAMES 32
+#define NUM_SCROLL_NAMES 32
+
 #include "TextEntry.h"
 class Constants
 {
@@ -590,7 +593,6 @@ public:
             JLog( LOG_LEVEL_ERROR, true, "got %d strings instead, misconfiguration error!\n", i );
         }
     };
-    TextEntry *m_StringTable;
 
     bool CompareType( const char *type, const char *szIn )
     {
@@ -659,5 +661,40 @@ public:
         }
         return m_StringTable[offset + index].m_szString;
     }
+
+    const char *PotionColor( const uint32 dwIndex )
+    {
+        if( dwIndex >= NUM_POTION_NAMES )
+            return "";
+        const char *PotionColors[] = {
+            "Clear",      "White",   "Black",    "Red",    "Pink",    "Orange",  "Yellow",
+            "Green",      "Blue",    "Purple",   "Brown",  "Gray",    "Golden",  "Silver",
+            "Ruby",       "Emerald", "Sapphire", "Amber",  "Rose",    "Lilac",   "Teal",
+            "Turquoise",  "Navy",    "Olive",    "Maroon", "Crimson", "Fuchsia", "Lavender",
+            "Chartreuse", "Gloopy",  "Bubbling", "Glowing" };
+        JLog( LOG_LEVEL_NOISE, true, "index %d value %s\n", dwIndex, PotionColors[dwIndex] );
+        return PotionColors[dwIndex];
+    }
+    const char *ScrollName( const uint32 dwIndex )
+    {
+        if( dwIndex >= NUM_SCROLL_NAMES )
+            return "";
+
+        const char *ScrollNames[] = {
+            "pizza",          "dolphin",       "coffee",       "doggos",       "dolor sit",
+            "amet consect",   "etur adipis",   "elit sed",     "do eius",      "mod tempor",
+            "didunt utbore",  "et aliqua",     "ut enim ad",   "veniam quis",  "nostrud exer",
+            "ullamco labo",   "ris nisi ut",   "aliquip ex",   "comm sequat",  "duis aute ir",
+            "uredo lorin",    "epre deriti",   "volute velit", "esse cillum",  "eu fugiat",
+            "nulla pariatur", "excesint occa", "ecat pidatat", "proident sun", "incul pafic",
+            "des erumol",     "id est laborum" };
+
+        return ScrollNames[dwIndex];
+    }
+
+public:
+    TextEntry *m_StringTable;
+
+protected:
 };
 #endif // __CONSTANTS_H__

--- a/src/FileParse.cpp
+++ b/src/FileParse.cpp
@@ -292,6 +292,14 @@ CItemDef *CDataFile::ReadItem( CItemDef &idIn )
     bool bStartItem = false;
     bool bEndItem = false;
 
+    int PotionIndex[NUM_POTION_NAMES];
+    Util::Shuffle( PotionIndex, NUM_POTION_NAMES );
+    int ScrollIndex[NUM_SCROLL_NAMES];
+    Util::Shuffle( ScrollIndex, NUM_SCROLL_NAMES );
+
+    uint32 potion_count = 0;
+    uint32 scroll_count = 0;
+
     while( !bEndItem && fgets( szRaw, 1024, m_fp ) != NULL )
     {
         szLine = Strip( szRaw );
@@ -379,6 +387,42 @@ CItemDef *CDataFile::ReadItem( CItemDef &idIn )
                 if( g_Constants.CompareType( "ITEM_IDX", szValue ) )
                 {
                     idIn.m_dwIndex = g_Constants.LookupString( szValue );
+                    if( idIn.m_dwIndex == ITEM_IDX_POTION )
+                    {
+                        int potion_index = PotionIndex[potion_count];
+                        idIn.m_szFlavor =
+                            new char[Util::jstrlen( g_Constants.PotionColor( potion_index ) ) + 1];
+                        Util::jstrcpy( idIn.m_szFlavor, g_Constants.PotionColor( potion_index ) );
+                        char szUnID[100];
+                        sprintf( szUnID, "%s Potion", idIn.m_szFlavor );
+                        idIn.m_szUnidentifiedName = new char[Util::jstrlen( szUnID ) + 1];
+                        Util::jstrcpy( idIn.m_szUnidentifiedName, szUnID );
+                        sprintf( szUnID, "%s Potions", idIn.m_szFlavor );
+
+                        idIn.m_szUnidentifiedPlural = new char[Util::jstrlen( szUnID ) + 1];
+                        Util::jstrcpy( idIn.m_szUnidentifiedPlural, szUnID );
+                        potion_count++;
+                    }
+                    else if( idIn.m_dwIndex == ITEM_IDX_SCROLL )
+                    {
+                        int scroll_index = ScrollIndex[scroll_count];
+                        idIn.m_szFlavor =
+                            new char[Util::jstrlen( g_Constants.ScrollName( scroll_index ) ) + 1];
+                        Util::jstrcpy( idIn.m_szFlavor, g_Constants.ScrollName( scroll_index ) );
+                        char szUnID[100];
+                        sprintf( szUnID, "Scroll labeled %s", idIn.m_szFlavor );
+                        idIn.m_szUnidentifiedName = new char[Util::jstrlen( szUnID ) + 1];
+                        Util::jstrcpy( idIn.m_szUnidentifiedName, szUnID );
+                        sprintf( szUnID, "Scrolls labeled %s", idIn.m_szFlavor );
+                        idIn.m_szUnidentifiedPlural = new char[Util::jstrlen( szUnID ) + 1];
+                        Util::jstrcpy( idIn.m_szUnidentifiedPlural, szUnID );
+                        scroll_count++;
+                    }
+                    else
+                    {
+                        idIn.m_szUnidentifiedName = idIn.m_szName;
+                        idIn.m_szUnidentifiedPlural = idIn.m_szPlural;
+                    }
                 }
             }
             else if( strncasecmp( szLine, "flags", 5 ) == 0 )

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -145,7 +145,7 @@ void CItem::SetColor()
 }
 
 unsigned char ItemIDs[ITEM_IDX_MAX + 1] = "|)[](]]\"=~{}{}&?!-_?$~//\\/|/|]";
-int EquipTypes[ITEM_IDX_MAX + 1] = {
+const int EquipTypes[ITEM_IDX_MAX + 1] = {
     EQUIP_IDX_MAIN_HAND, EQUIP_IDX_OFF_HAND,  EQUIP_IDX_ARMOR,     EQUIP_IDX_HELMET,
     EQUIP_IDX_CLOAK,     EQUIP_IDX_GLOVES,    EQUIP_IDX_BOOTS,     EQUIP_IDX_AMULET,
     EQUIP_IDX_RING,      EQUIP_IDX_TORCH,     EQUIP_IDX_MAIN_HAND, EQUIP_IDX_AMMO,
@@ -162,6 +162,31 @@ int CItem::EquipType()
         return EQUIP_IDX_INVALID;
     return EquipTypes[item_type];
 }
+
+char *CItem::GetName()
+{
+    if( false ) // IsIdentified() ) // TODO: MIKE: ID goes here
+    {
+        return m_id->m_szName;
+    }
+    else
+    {
+        return m_id->m_szUnidentifiedName;
+    }
+}
+
+char *CItem::GetPlural()
+{
+    if( false ) // IsIdentified() )// TODO: MIKE: ID goes here
+    {
+        return m_id->m_szPlural;
+    }
+    else
+    {
+        return m_id->m_szUnidentifiedPlural;
+    }
+}
+
 void CItem::Draw()
 {
     // Don't draw if something else is there.

--- a/src/Item.h
+++ b/src/Item.h
@@ -23,6 +23,7 @@ public:
     CItemDef()
         : m_szName( NULL ),
           m_szPlural( NULL ),
+          m_szFlavor( NULL ),
           m_fSpeed( 0.0f ),
           m_fACBonus( 0.0f ),
           m_fBaseAC( 0.0f ),
@@ -71,6 +72,9 @@ public:
     }
     char *m_szName; // what item is this?
     char *m_szPlural;
+    char *m_szUnidentifiedName;
+    char *m_szUnidentifiedPlural;
+    char *m_szFlavor; // "Green" Potion
     float m_fSpeed;
     float m_fACBonus;
     float m_fBaseAC;
@@ -127,8 +131,8 @@ public:
     void Init( CItemDef *pid );
     void SetCursed( int likelihood );
     void SetCursed( bool bCursed );
-    char *GetName() { return m_id->m_szName; }
-    char *GetPlural() { return m_id->m_szPlural; }
+    char *GetName();
+    char *GetPlural();
     bool IsStackable() { return ( m_id->m_dwFlags & ITEM_FLAG_STACKS ) == ITEM_FLAG_STACKS; }
     bool IsOpenable() { return false; }   // for chests, etc.
     bool IsCloseable() { return false; }  // closeable pickup?

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -107,6 +107,22 @@ float Roll( const char *szFormat )
     return Roll( dice, sides );
 }
 
+void Shuffle( int *array, const uint32 size )
+{
+    for( int i = 0; i < size; i++ )
+    {
+        array[i] = i;
+    }
+
+    for( int i = size - 1; i > 0; i-- )
+    {
+        int j = rand() % ( i + 1 );
+        int temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+}
+
 bool IsInWorld( JIVector vIn ) { return vIn.IsInWorld(); }
 bool IsWithinWorld( JIVector vIn ) { return vIn.IsWithinWorld(); }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -16,6 +16,8 @@ JIVector GetRandomPoint( const JRect rcIn );
 float Roll( int dice, int sides );
 float Roll( const char *szFormat );
 
+void Shuffle( int *array, const uint32 size );
+
 JRect Edges( const JRect rcIn );
 
 bool IsInWorld( JFVector vIn );


### PR DESCRIPTION
added Shuffle to scramble a list of indices
items now have an unIDd name and a different one for when identified

Scrolls and Potions get a scrambled name when not identified
they will display "normal" name when identified

we should use this more deepy for magic ID also