### PR TITLE
fix: Turn Based means monsters don't move until player finishes command

### DIFF
--- a/src/CmdState.cpp
+++ b/src/CmdState.cpp
@@ -113,7 +113,7 @@ int CCmdState::OnHandleKey( SDL_Keysym *keysym )
     {
         g_pGame->SetState( STATE_RANGED );
         g_pGame->GetGameState()->HandleKey( keysym );
-        retval = 0;
+        retval = -1;
     }
 
     // Wizard-mode commands

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -212,6 +212,11 @@ void CPlayer::DisplayStats()
         g_pGame->GetStats()->Printf( "Target: %s\n", m_pTarget->GetName() );
         g_pGame->GetStats()->Printf( "\n" );
         g_pGame->GetStats()->Printf( "\n" );
+        if( IsWizard() )
+        {
+            g_pGame->GetStats()->Printf( "Target Pos: <%.0f %.0f>\n",
+                                         VEC_EXPAND( m_pTarget->GetPos() ) );
+        }
     }
     if( IsWizard() )
     {

--- a/src/RangedState.cpp
+++ b/src/RangedState.cpp
@@ -528,7 +528,8 @@ bool CRangedState::DoTrajectory()
     case DUNG_COLL_PLAYER:
         break;
     default:
-        JLog( LOG_LEVEL_ERROR, true, "invalid collision type: %d\n", collide_type );
+        JLog( LOG_LEVEL_ERROR, true, "invalid collision at <%f %f> type: %d\n", VEC_EXPAND( vTest ),
+              collide_type );
         ResetToState( STATE_COMMAND );
         return false;
         break;
@@ -595,6 +596,6 @@ void CRangedState::UsePlayerTarget()
     vDelta *= 8.0f; // TODO: actual range of item
     m_vTarget.Init( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos + vDelta ) );
 
-    JLog( LOG_LEVEL_DEBUG, true, "cur <%d %d> tar <%d %d> del <%.2f %.2f>\n",
+    JLog( LOG_LEVEL_ERROR, true, "cur <%d %d> tar <%d %d> del <%.2f %.2f>\n",
           VEC_EXPAND( m_vCurrentPosition ), VEC_EXPAND( m_vTarget ), VEC_EXPAND( vDelta ) );
 }

--- a/src/RangedState.cpp
+++ b/src/RangedState.cpp
@@ -589,13 +589,8 @@ bool CRangedState::DoZap() { return g_pGame->GetPlayer()->Zap( m_pSelected ) == 
 void CRangedState::UsePlayerTarget()
 {
     m_vCurrentPosition.Init( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos ) );
-    // construct target pos in the direction of the player target (to allow passing through the
-    // target)
-    JVector vDelta = g_pGame->GetPlayer()->GetTarget()->GetPos() - g_pGame->GetPlayer()->m_vPos;
-    vDelta.Norm();
-    vDelta *= 8.0f; // TODO: actual range of item
-    m_vTarget.Init( VEC_EXPAND( g_pGame->GetPlayer()->m_vPos + vDelta ) );
+    m_vTarget.Init( VEC_EXPAND( g_pGame->GetPlayer()->GetTarget()->GetPos() ) );
 
-    JLog( LOG_LEVEL_ERROR, true, "cur <%d %d> tar <%d %d> del <%.2f %.2f>\n",
-          VEC_EXPAND( m_vCurrentPosition ), VEC_EXPAND( m_vTarget ), VEC_EXPAND( vDelta ) );
+    JLog( LOG_LEVEL_DEBUG, true, "cur <%d %d> tar <%d %d>\n", VEC_EXPAND( m_vCurrentPosition ),
+          VEC_EXPAND( m_vTarget ) );
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -296,23 +296,10 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
         }
         else
         {
-            vCurrent.x += vStep.x; // Always increment x
+            vCurrent.x += vStep.x; // Increment x if error is negative
             error += 2 * vDelta.y;
             alreadyAdded = false;
         }
-        // errorx2 += error * 2;
-        // if( errorx2 > -vDelta.y )
-        // {
-        //     error -= vDelta.y;
-        //     vCurrent.x += vStep.x;
-        //     alreadyAdded = false;
-        // }
-        // if( errorx2 < vDelta.x )
-        // {
-        //     error += vDelta.x;
-        //     vCurrent.y += vStep.y;
-        //     alreadyAdded = false;
-        // }
         JLog( LOG_LEVEL_NOISE, true, "bres still going\n" );
     }
     return true;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -249,8 +249,7 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
     // Bresenham Line Algorithm
     JIVector vDelta( abs( vTarget.x - vSource.x ), abs( vTarget.y - vSource.y ) );
     JIVector vStep( vSource.x < vTarget.x ? 1 : -1, vSource.y < vTarget.y ? 1 : -1 );
-    int error = vDelta.x - vDelta.y;
-    int errorx2;
+    int error = 2 * ( vDelta.x - vDelta.y );
 
     JVector vTest;
     JIVector vCurrent = vSource;
@@ -266,7 +265,7 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
         }
         if( !alreadyAdded )
         {
-            JLog( LOG_LEVEL_DEBUG, true, "bres added <%d %d>\n", VEC_EXPAND( vCurrent ) );
+            JLog( LOG_LEVEL_WARN, true, "bres added <%d %d>\n", VEC_EXPAND( vCurrent ) );
             if( llLine )
                 llLine->Add( new JIVector( vCurrent ) );
             alreadyAdded = true;
@@ -287,19 +286,32 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
                 return false;
             }
         }
-        errorx2 += error * 2;
-        if( errorx2 > -vDelta.y )
+
+        if( error < 0 )
         {
-            error -= vDelta.y;
-            vCurrent.x += vStep.x;
+            vCurrent.y += vStep.y; // Increment y if error is positive
+            error -= 2 * vDelta.x;
             alreadyAdded = false;
         }
-        if( errorx2 < vDelta.x )
+        else
         {
-            error += vDelta.x;
-            vCurrent.y += vStep.y;
+            vCurrent.x += vStep.x; // Always increment x
+            error += 2 * vDelta.y;
             alreadyAdded = false;
         }
+        // errorx2 += error * 2;
+        // if( errorx2 > -vDelta.y )
+        // {
+        //     error -= vDelta.y;
+        //     vCurrent.x += vStep.x;
+        //     alreadyAdded = false;
+        // }
+        // if( errorx2 < vDelta.x )
+        // {
+        //     error += vDelta.x;
+        //     vCurrent.y += vStep.y;
+        //     alreadyAdded = false;
+        // }
         JLog( LOG_LEVEL_NOISE, true, "bres still going\n" );
     }
     return true;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -249,7 +249,7 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
     // Bresenham Line Algorithm
     JIVector vDelta( abs( vTarget.x - vSource.x ), abs( vTarget.y - vSource.y ) );
     JIVector vStep( vSource.x < vTarget.x ? 1 : -1, vSource.y < vTarget.y ? 1 : -1 );
-    int error = 2 * ( vDelta.x - vDelta.y );
+    int error = 2 * ( vDelta.y - vDelta.x );
 
     JVector vTest;
     JIVector vCurrent = vSource;
@@ -265,7 +265,8 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
         }
         if( !alreadyAdded )
         {
-            JLog( LOG_LEVEL_WARN, true, "bres added <%d %d>\n", VEC_EXPAND( vCurrent ) );
+            JLog( LOG_LEVEL_WARN, true, "bres added <%d %d> error: %d\n", VEC_EXPAND( vCurrent ),
+                  error );
             if( llLine )
                 llLine->Add( new JIVector( vCurrent ) );
             alreadyAdded = true;
@@ -287,7 +288,7 @@ bool Bresenham( const JIVector vSource, const JIVector vTarget, const uint8 dist
             }
         }
 
-        if( error < 0 )
+        if( error > 0 )
         {
             vCurrent.y += vStep.y; // Increment y if error is positive
             error -= 2 * vDelta.x;


### PR DESCRIPTION
* fix Bresenham error calculation

Note: 
* some commands should not induce monster movement
* inventory, equipment should not cost a turn at all
* reading, quaffing, zapping should only allow movement after the inventory item is selected.
* wield, remove, drop should all take just one turn (no move until after select)
