### PR TITLE
docs: Add branching strategy to developer guide

### DIFF
--- a/_JMoria Developer's Guide.md
+++ b/_JMoria Developer's Guide.md
@@ -1,5 +1,27 @@
 #  JMoria Developer's Guide
 
+## Branching Strategy
+
+Use the following branch naming convention:
+
+```
+<gh-username>/<branch-type>/<feature-name>
+```
+
+**Branch types:**
+- `feat/` - New features
+- `fix/` - Bug fixes
+- `refactor/` - Code refactoring
+- `docs/` - Documentation updates
+- `test/` - Test additions or fixes
+
+**Examples:**
+- `mschober/feat/linux-install`
+- `mschober/fix/opengl-header`
+- `mschober/refactor/dungeon-generation`
+
+Create a Pull Request to `develop` when your feature is ready for review.
+
 ## Adding a new Monster
 1) If you are creating a new flavor of an existing monster (adding a new type of orc), you just need to:
         a) edit *Monsters.txt*


### PR DESCRIPTION
## Summary
- Add branch naming convention documentation to the developer guide
- Format: `<gh-username>/<branch-type>/<feature-name>`
- Includes branch types: feat, fix, refactor, docs, test

## Test plan
- [ ] Review documentation for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)