### PR TITLE
fix: Update test build.sh for Linux and modern gtest

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -x
-# Compile
-g++ -c -o bin/AllSteps.o features/step_definitions/AllSteps.cpp -I../../JMoria/src -std=c++11 -Wno-comment -Wno-delete-non-virtual-dtor
+# Compile (C++14 required for gtest)
+g++ -c -o bin/AllSteps.o features/step_definitions/AllSteps.cpp -I../../JMoria/src -std=c++14 -Wno-comment -Wno-delete-non-virtual-dtor
 
 # Link (exclude main.o to avoid duplicate globals when linking test runner)
 OBJFILES=$(ls ../../JMoria/src/*.o | grep -v '/main.o' || true)
-g++ -o bin/AllSteps bin/AllSteps.o $OBJFILES -L/usr/local/lib -lcucumber-cpp -lc++ -lboost_program_options -lboost_regex -lboost_filesystem -lboost_system -lgtest -lSDL2 -lSDL2_image -framework OpenGL
+g++ -o bin/AllSteps bin/AllSteps.o $OBJFILES -L/usr/local/lib -lcucumber-cpp -lboost_program_options -lboost_regex -lboost_filesystem -lboost_system -lgtest -lSDL2 -lSDL2_image -lGL
 # gcc -o bin/AllSteps features/step_definitions/AllSteps.cpp ../../JMoria/Util.cpp ../../JMoria/Tileset.cpp -L/usr/local/lib -lcucumber-cpp -lc++ -lboost_program_options -lboost_regex -lboost_filesystem -lboost_system -lgtest -I../../JMoria -std=c++11 -Wno-comment -Wno-delete-non-virtual-dtor
 # gcc -o bin/FirstSteps features/step_definitions/FirstSteps.cpp -L/usr/local/lib -lcucumber-cpp -lc++ -lboost_program_options -lboost_regex -lboost_filesystem -lboost_system -lgtest -I../../JMoria -std=c++11 -Wno-comment -Wno-delete-non-virtual-dtor


### PR DESCRIPTION
## Summary

- Use C++14 (required by gtest on Ubuntu 24.04)
- Replace `-framework OpenGL` (macOS) with `-lGL` (Linux)
- Remove `-lc++` (not needed on Linux)

## Test plan

- [x] `./build.sh` compiles successfully on Linux
- [x] `./runtests.sh brains` passes (3 scenarios, 17 steps)
- [x] `./runtests.sh vectors` passes (16 scenarios, 45 steps)
- [x] `./runtests.sh rects` passes (15 scenarios, 36 steps)
- [ ] Verify build works on macOS (may need platform detection)

## Notes

This change replaces macOS-specific `-framework OpenGL` with Linux `-lGL`. May need to add platform detection to support both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)