### PR TITLE
Fix #169: Redirect JLog stderr output to file in ASCII mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 # G++
 *.o
 jmoria
+jmoria.log
 
 # Cucumber
 bin/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,13 @@ int main( int argc, char **argv )
     renderMode = RenderMode::OpenGL;
 #endif
 
+    // Redirect stderr to a log file in ASCII mode so JLog output
+    // doesn't corrupt the ncurses display.
+    if( renderMode == RenderMode::ASCII )
+    {
+        freopen( "jmoria.log", "w", stderr );
+    }
+
     JResult result;
     g_pGame = new CGame;
 


### PR DESCRIPTION
## Problem

When running in `--renderer=ascii` mode, `JLog()` writes to stderr via `vfprintf()`, which goes directly to the terminal and corrupts the ncurses-managed display. This is most severe during level transitions (spawn logs, room/hallway counts) but also affects normal gameplay (combat roll logs, wield debug output, warn-level messages).

The corruption persists because `ncurses::erase()` only clears its virtual screen — raw terminal writes from JLog remain in the buffer.

## Fix

Added `freopen("jmoria.log", "w", stderr)` in `main.cpp` when ASCII mode is selected, **before** `CGame::Init()` and ncurses initialization. Since all `JLog()` calls already route through `vfprintf(stderr, ...)`, this single redirect captures all log output — level generation info, combat to-hit/damage rolls, wield slot debug, AI pathing, etc. — and writes it to `jmoria.log` instead of the terminal.

OpenGL mode is unaffected; stderr continues to the terminal as before.

Also added `jmoria.log` to `.gitignore`.

## Changes

- `src/main.cpp`: `freopen("jmoria.log", "w", stderr)` when `renderMode == RenderMode::ASCII`
- `.gitignore`: added `jmoria.log`

## Testing

- Verified build succeeds on macOS
- Traced all `JLog()` calls in combat path (`Player.cpp` to-hit/damage), wield path (`Player.cpp`, `UseState.cpp`), and level generation (`Dungeon.cpp`, `Monster.cpp`, `Item.cpp`) — all use `vfprintf(stderr)` and will be captured
- Player-visible messages (`GetMsgs()->Printf()`) are unaffected — they render through `CDisplayText`/ncurses as intended

Closes #169