### PR TITLE
WORKLIST: Happy wanderer exploration (#213)

### DIFF
--- a/WORKLIST_happy_wanderer.md
+++ b/WORKLIST_happy_wanderer.md
@@ -1,0 +1,86 @@
+# Happy Wanderer Exploration — Work List
+
+## Overview
+
+This work list tracks the implementation of depth-first, committed exploration for the JMoria bot. See **Issue #213** for the full problem statement and design rationale.
+
+The bot currently uses BFS (`_nearest_unexplored_tile()`) to pick the next exploration target, which produces breadth-first wandering — ping-ponging between frontiers, partially exploring areas, and skipping doors at hallway ends. The goal is to replace this with exploration that commits to clearing one area before moving to the next.
+
+---
+
+## Priority 1: Direction-biased target selection (core fix)
+
+**[P1.1] Add directional continuation scoring to `_nearest_unexplored_tile()`**
+- When scoring frontier tiles, add a bonus for tiles that continue in the bot's current travel direction.
+- Use `last_action` (directional char) to determine the current heading.
+- Tiles "ahead" of the bot should score better than equidistant tiles behind or to the side.
+- This directly addresses mid-hallway turnarounds and hallway-end door avoidance.
+
+**[P1.2] Prefer forward-reachable frontier over globally nearest**
+- When the bot is in a hallway or corridor, bias strongly toward the frontier tile at the far end rather than a closer tile in a previously-visited area.
+- Consider a two-pass approach: first check for reachable frontier tiles in the forward arc, then fall back to BFS if none exist.
+
+**[P1.3] Reduce backtracking after door encounters**
+- When the bot is adjacent to a closed door with unknown tiles behind it, that door should win over a slightly-closer unexplored tile behind the bot.
+- The existing door scoring (score=0 for closed doors with unknown neighbors) may need to factor in distance-from-bot so nearby doors always beat far-away floor tiles.
+
+## Priority 2: Frontier clustering (area commitment)
+
+**[P2.1] Identify connected frontier clusters**
+- Group contiguous unexplored frontier tiles into clusters (connected components).
+- Each cluster represents an "area" the bot could commit to clearing.
+
+**[P2.2] Commit to clearing current cluster before switching**
+- Once the bot begins exploring a cluster, continue targeting tiles within that cluster until it's fully explored.
+- Only switch clusters when the current one is exhausted or unreachable.
+- This directly fixes the "explore half a dark room, leave, come back later" pattern.
+
+**[P2.3] Score clusters by proximity and size**
+- When choosing which cluster to explore next, prefer nearby clusters (minimize travel) and larger clusters (more efficient to clear).
+
+## Priority 3: Door proximity boost
+
+**[P3.1] Boost score for doors adjacent to current path**
+- When the bot's A* path passes within 1-2 tiles of a closed door, boost that door's exploration priority.
+- Prevents "walk past a door in a hallway without opening it" behavior.
+
+**[P3.2] Opportunistic door opening during traversal**
+- If the bot is pathfinding through a hallway and a closed door is directly adjacent (perpendicular), consider opening it as a low-cost side action before continuing.
+
+## Priority 4: Measurement and validation
+
+**[P4.1] Add exploration efficiency metrics to crawler output**
+- Track: total turns to clear level, unique tiles visited vs total walkable, number of frontier switches, number of backtrack segments.
+- Output to crawler log for before/after comparison.
+
+**[P4.2] Baseline current exploration behavior**
+- Run crawler with current code: record turns-to-clear, tile coverage, and frontier-switch count across multiple runs.
+- Save as baseline for comparison.
+
+**[P4.3] Validate improvements against baseline**
+- After each priority tier is implemented, re-run crawler and compare against baseline.
+- Target: fewer frontier switches, fewer total turns, more complete area coverage before moving on.
+
+## Priority 5: Edge cases and polish
+
+**[P5.1] Handle dark room exploration specifically**
+- Dark rooms (no light source) require tile-by-tile discovery.
+- When inside a dark room, switch to a systematic sweep pattern (e.g., spiral or row-scan) to avoid missing interior tiles.
+- Related: Issue #200.
+
+**[P5.2] Avoid oscillation between two equidistant frontiers**
+- Add hysteresis: once the bot commits to a direction, require a meaningful reason to reverse (e.g., current frontier exhausted, new high-priority item visible).
+- Track "committed direction" and apply a penalty for reversals.
+
+**[P5.3] Graceful fallback when DFS-style gets stuck**
+- If directional bias leads to a dead end with no forward frontier, fall back to global BFS cleanly.
+- Ensure stuck_turns detection still works correctly with the new scoring.
+
+---
+
+## Implementation Notes
+
+- All changes are in `scripts/bot/decision.py` and possibly `scripts/bot/pathfinding.py`.
+- The goal stack structure (LIFO with type/position tuples) should remain unchanged.
+- A* pathfinding and door momentum are working correctly — this work is about **which target to pick**, not how to get there.
+- Test via `scripts/crawl.sh` and bot test harness; validate with before/after crawler metrics.

--- a/scripts/bot/decision.py
+++ b/scripts/bot/decision.py
@@ -69,7 +69,7 @@ class DecisionEngine:
         # Goal-based exploration state machine.
         self.explore_phase = "head_east"
         self.door_momentum = False
-        self.known_map = [["~"] * 100 for _ in range(100)]
+        self.known_map = [["\x00"] * 100 for _ in range(100)]
         self._current_depth = 1
         self.failed_door_dirs_by_world = {}
         # Door graph: nodes = door world positions, edges = same-room connectivity.
@@ -141,7 +141,7 @@ class DecisionEngine:
         if state.dungeon_depth != self.last_depth:
             self.equip_attempt_counts.clear()
             self.phantom_positions.clear()
-            self.known_map = [["~"] * 100 for _ in range(100)]
+            self.known_map = [["\x00"] * 100 for _ in range(100)]
             self.door_graph = {}
             self.explored_doors = set()
             self.last_door_wpos = None
@@ -452,11 +452,21 @@ class DecisionEngine:
                     for d in pf.DIRS_8:
                         if d != last_dir:
                             check_dirs.append(d)
+                    chained = False
                     for dr, dc in check_dirs:
                         nr, nc = mpos[0] + dr, mpos[1] + dc
                         if (nr, nc) in self.unexplored_tiles:
                             self.goal_stack.append(("unexplored", (nr, nc)))
+                            chained = True
                             break
+                    # #213: No adjacent frontier — use directional
+                    # search to stay on course instead of falling
+                    # through to a headingless BFS.
+                    if not chained:
+                        target = self._nearest_unexplored_tile(
+                            mpos, heading=last_dir)
+                        if target:
+                            self.goal_stack.append(("unexplored", target))
                     continue
                 break
             elif gtype == "staircase":
@@ -478,7 +488,8 @@ class DecisionEngine:
 
         # If stack empty, push nearest unexplored tile or staircase.
         if not self.goal_stack:
-            target = self._nearest_unexplored_tile(mpos)
+            heading = KEY_TO_DIR.get(self.last_action)
+            target = self._nearest_unexplored_tile(mpos, heading=heading)
             if target:
                 self.goal_stack.append(("unexplored", target))
 
@@ -773,7 +784,7 @@ class DecisionEngine:
         for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
             nr, nc = r + dr, c + dc
             if 0 <= nr < 100 and 0 <= nc < 100:
-                if self.known_map[nr][nc] == "~":
+                if self.known_map[nr][nc] == "\x00":
                     return True
         return False
 
@@ -787,14 +798,22 @@ class DecisionEngine:
                     return (nr, nc)
         return None
 
-    def _nearest_unexplored_tile(self, wpos):
-        """BFS on known_map to find nearest frontier tile by walk distance.
+    def _nearest_unexplored_tile(self, wpos, heading=None):
+        """BFS on known_map to find the best frontier tile (#213).
 
         Frontier tiles are already-seen walkable tiles that border the
-        unknown.  Among equally-close candidates we prefer hallway edges
-        (tiles with few walkable neighbors — likely corridors leading
-        into new territory) over open room edges.
+        unknown.  Candidates are scored by a composite of walk distance,
+        corridor preference (fewer walkable neighbors), directional
+        alignment with *heading*, and door bonuses.
+
+        When *heading* is provided the search looks up to
+        DIRECTION_LOOKAHEAD steps beyond the nearest candidate so that
+        a tile slightly farther away but in the forward direction can
+        beat a closer tile behind the bot.  This prevents mid-hallway
+        turnarounds and backtracking past doors.
         """
+        DIRECTION_LOOKAHEAD = 4
+
         if not self.unexplored_tiles:
             return None
         candidates = self.unexplored_tiles - self.failed_goals
@@ -803,34 +822,45 @@ class DecisionEngine:
         visited = {wpos}
         queue = deque([(wpos, 0)])
         best = None
-        best_dist = None
         best_score = 999
+        first_dist = None  # distance to first candidate found
         while queue:
             cur, dist = queue.popleft()
-            if best_dist is not None and dist > best_dist:
-                break
+            # Search window: exact match when no heading, otherwise
+            # allow DIRECTION_LOOKAHEAD extra steps.
+            if first_dist is not None:
+                limit = first_dist + (DIRECTION_LOOKAHEAD if heading else 0)
+                if dist > limit:
+                    break
             if cur in candidates:
-                # Score: fewer walkable neighbors = more corridor-like = better
-                score = sum(
+                if first_dist is None:
+                    first_dist = dist
+                # Corridor preference: fewer walkable neighbors = better.
+                neighbor_score = sum(
                     1 for dr, dc in pf.DIRS_8
                     if 0 <= cur[0]+dr < 100 and 0 <= cur[1]+dc < 100
                     and self.known_map[cur[0]+dr][cur[1]+dc] in (".", "'", "<", ">")
                 )
-                if best is None or score < best_score:
+                # Door bonus: closed doors with unknown territory behind
+                # them are high-value targets.
+                if self.known_map[cur[0]][cur[1]] == "+":
+                    neighbor_score = 0
+                # Direction penalty / bonus (#213).
+                dir_penalty = 0
+                if heading and (cur[0] != wpos[0] or cur[1] != wpos[1]):
+                    dr = cur[0] - wpos[0]
+                    dc = cur[1] - wpos[1]
+                    mag = max(abs(dr), abs(dc))
+                    if mag > 0:
+                        dot = (heading[0] * dr + heading[1] * dc) / mag
+                        if dot >= 0.5:
+                            dir_penalty = -2  # forward bonus
+                        elif dot <= -0.5:
+                            dir_penalty = 3   # backward penalty
+                score = dist + neighbor_score + dir_penalty
+                if score < best_score:
                     best = cur
-                    best_dist = dist
                     best_score = score
-                continue
-            # Also check for closed doors adjacent to BFS frontier.
-            for dr, dc in pf.DIRS_8:
-                nr, nc = cur[0] + dr, cur[1] + dc
-                if 0 <= nr < 100 and 0 <= nc < 100:
-                    npos = (nr, nc)
-                    if self.known_map[nr][nc] == "+" and self._has_unknown_neighbor(npos):
-                        if best is None:
-                            best = npos
-                            best_dist = dist + 1
-                            best_score = 0  # doors always top priority
             # Expand BFS through walkable AND unknown tiles.
             for dr, dc in pf.DIRS_8:
                 nr, nc = cur[0] + dr, cur[1] + dc

--- a/scripts/bot/decision.py
+++ b/scripts/bot/decision.py
@@ -97,6 +97,14 @@ class DecisionEngine:
         self.items_picked_up = 0
         self.deepest_depth = 1
         self.hp_history = []  # last 10 HP values for trend
+        # Exploration efficiency metrics (#213 P4).
+        self.frontier_switches = 0   # times we picked a new unexplored target
+        self.cluster_switches = 0    # times current_cluster changed
+        self.backtrack_steps = 0     # steps moving away from goal
+        self.explore_steps = 0       # steps moving toward or at goal
+        self.level_unique_tiles = set()  # unique world positions visited this level
+        self._prev_goal_target = None
+        self._prev_dist_to_goal = None
 
     def decide(self, state):
         self.mode = "seek"
@@ -158,6 +166,13 @@ class DecisionEngine:
             self.last_staircase_attempt = None
             self.staircase_attempt_cooldown = 0
             self.level_kills = 0
+            self.frontier_switches = 0
+            self.cluster_switches = 0
+            self.backtrack_steps = 0
+            self.explore_steps = 0
+            self.level_unique_tiles = set()
+            self._prev_goal_target = None
+            self._prev_dist_to_goal = None
             self.deepest_depth = max(self.deepest_depth, state.dungeon_depth)
             self.last_depth = state.dungeon_depth
 
@@ -881,6 +896,7 @@ class DecisionEngine:
                 )
                 self.current_cluster = best_cluster
                 active_cluster = best_cluster
+                self.cluster_switches += 1
 
         visited = {wpos}
         queue = deque([(wpos, 0)])
@@ -987,6 +1003,24 @@ class DecisionEngine:
 
     def _record_decision(self, action, thought):
         self.last_thought = thought
+        # Track exploration efficiency (#213 P4).
+        if self.current_motion_pos is not None:
+            self.level_unique_tiles.add(self.current_motion_pos)
+        if self.goal_stack:
+            gt, grc = self.goal_stack[-1]
+            if grc != self._prev_goal_target:
+                if self._prev_goal_target is not None and gt == "unexplored":
+                    self.frontier_switches += 1
+                self._prev_goal_target = grc
+                self._prev_dist_to_goal = None
+            if self.current_motion_pos is not None:
+                cur_dist = pf.heuristic(self.current_motion_pos, grc)
+                if self._prev_dist_to_goal is not None:
+                    if cur_dist < self._prev_dist_to_goal:
+                        self.explore_steps += 1
+                    elif cur_dist > self._prev_dist_to_goal:
+                        self.backtrack_steps += 1
+                self._prev_dist_to_goal = cur_dist
         return self._record_action(action)
 
     def debug_thought(self):
@@ -1134,6 +1168,9 @@ class DecisionEngine:
             f"Items={self.items_picked_up}\n"
             f"  Explored={pct:.0f}% ({explored}/{total})  "
             f"Goals={len(self.goal_stack)}\n"
+            f"  FrontierSw={self.frontier_switches}  ClusterSw={self.cluster_switches}  "
+            f"Backtrack={self.backtrack_steps}/{self.explore_steps + self.backtrack_steps}  "
+            f"UniqTiles={len(self.level_unique_tiles)}\n"
             f"========================="
         )
 
@@ -1197,6 +1234,8 @@ class DecisionEngine:
     def run_summary(self, turn):
         """Aggregate stats printed at end of run."""
         knowledge_entries = len(self.monster_knowledge) + len(self.consumable_knowledge)
+        total_steps = self.explore_steps + self.backtrack_steps
+        bt_pct = (self.backtrack_steps / total_steps * 100) if total_steps > 0 else 0
 
         return (
             f"=== Run Summary ===\n"
@@ -1204,6 +1243,9 @@ class DecisionEngine:
             f"Total kills={self.total_kills}\n"
             f"  Items collected={self.items_picked_up}  "
             f"Knowledge entries={knowledge_entries}\n"
+            f"  FrontierSw={self.frontier_switches}  ClusterSw={self.cluster_switches}  "
+            f"Backtrack={self.backtrack_steps}/{total_steps} ({bt_pct:.0f}%)\n"
+            f"  UniqTiles={len(self.level_unique_tiles)}\n"
             f"==================="
         )
 

--- a/scripts/bot/decision.py
+++ b/scripts/bot/decision.py
@@ -81,6 +81,8 @@ class DecisionEngine:
         # Tile-level exploration tracking.
         self.unexplored_tiles = set()
         self.explored_tiles = set()
+        # Frontier clustering (#213 P2): commit to clearing one area.
+        self.current_cluster = set()
         # Goal stack: LIFO list of (goal_type, (row, col)).
         self.goal_stack = []
         self.pushed_goals = set()
@@ -149,6 +151,7 @@ class DecisionEngine:
             self.cached_path_target = None
             self.unexplored_tiles = set()
             self.explored_tiles = set()
+            self.current_cluster = set()
             self.goal_stack = []
             self.pushed_goals = set()
             self.failed_goals = set()
@@ -735,6 +738,7 @@ class DecisionEngine:
                         new_frontier.add((r, c))
 
         self.unexplored_tiles = new_frontier
+        self._rebuild_current_cluster()
 
         # Prune stale unexplored goals from anywhere in the stack (#209).
         # This handles scroll-of-light or other visibility changes that
@@ -773,6 +777,46 @@ class DecisionEngine:
         # Only push item goals.
         self.goal_stack.extend(new_items)
 
+    def _rebuild_current_cluster(self):
+        """Prune current_cluster to only tiles still in the frontier.
+
+        When the cluster is fully exhausted, clear it so
+        _nearest_unexplored_tile will pick the next best cluster.
+        """
+        self.current_cluster &= self.unexplored_tiles
+
+    def _build_frontier_clusters(self):
+        """Compute connected components of unexplored frontier tiles (#213 P2).
+
+        Two frontier tiles are in the same cluster if they are connected
+        through walkable tiles (8-directional).  Returns a list of sets.
+        """
+        candidates = self.unexplored_tiles - self.failed_goals
+        if not candidates:
+            return []
+        remaining = set(candidates)
+        clusters = []
+        while remaining:
+            seed = next(iter(remaining))
+            cluster = set()
+            queue = deque([seed])
+            visited = {seed}
+            while queue:
+                cur = queue.popleft()
+                if cur in remaining:
+                    cluster.add(cur)
+                for dr, dc in pf.DIRS_8:
+                    nr, nc = cur[0] + dr, cur[1] + dc
+                    npos = (nr, nc)
+                    if npos not in visited and 0 <= nr < 100 and 0 <= nc < 100:
+                        ch = self.known_map[nr][nc]
+                        if pf.is_passable(ch) or npos in remaining:
+                            visited.add(npos)
+                            queue.append(npos)
+            remaining -= cluster
+            clusters.append(cluster)
+        return clusters
+
     def _has_unknown_neighbor(self, world_pos):
         """True if any cardinal neighbor in known_map is unseen (~).
 
@@ -804,21 +848,40 @@ class DecisionEngine:
         Frontier tiles are already-seen walkable tiles that border the
         unknown.  Candidates are scored by a composite of walk distance,
         corridor preference (fewer walkable neighbors), directional
-        alignment with *heading*, and door bonuses.
+        alignment with *heading*, door bonuses, and cluster commitment.
 
         When *heading* is provided the search looks up to
         DIRECTION_LOOKAHEAD steps beyond the nearest candidate so that
         a tile slightly farther away but in the forward direction can
         beat a closer tile behind the bot.  This prevents mid-hallway
         turnarounds and backtracking past doors.
+
+        Cluster commitment (#213 P2): if current_cluster has tiles
+        remaining, strongly prefer those tiles.  If exhausted, pick the
+        nearest cluster and commit to it.
         """
         DIRECTION_LOOKAHEAD = 4
+        CLUSTER_BONUS = -5  # strong preference for current cluster
 
         if not self.unexplored_tiles:
             return None
         candidates = self.unexplored_tiles - self.failed_goals
         if not candidates:
             return None
+
+        # If current cluster is empty, pick a new one.
+        active_cluster = self.current_cluster & candidates
+        if not active_cluster:
+            clusters = self._build_frontier_clusters()
+            if clusters:
+                # Pick cluster whose nearest tile (Chebyshev) is closest.
+                best_cluster = min(
+                    clusters,
+                    key=lambda c: min(pf.heuristic(wpos, t) for t in c)
+                )
+                self.current_cluster = best_cluster
+                active_cluster = best_cluster
+
         visited = {wpos}
         queue = deque([(wpos, 0)])
         best = None
@@ -858,6 +921,9 @@ class DecisionEngine:
                         elif dot <= -0.5:
                             dir_penalty = 3   # backward penalty
                 score = dist + neighbor_score + dir_penalty
+                # Cluster commitment (#213 P2).
+                if active_cluster and cur in active_cluster:
+                    score += CLUSTER_BONUS
                 if score < best_score:
                     best = cur
                     best_score = score

--- a/scripts/bot/decision.py
+++ b/scripts/bot/decision.py
@@ -105,6 +105,8 @@ class DecisionEngine:
         self.level_unique_tiles = set()  # unique world positions visited this level
         self._prev_goal_target = None
         self._prev_dist_to_goal = None
+        # Anti-oscillation (#213 P5.2).
+        self._recent_positions = deque(maxlen=6)
 
     def decide(self, state):
         self.mode = "seek"
@@ -173,6 +175,7 @@ class DecisionEngine:
             self.level_unique_tiles = set()
             self._prev_goal_target = None
             self._prev_dist_to_goal = None
+            self._recent_positions.clear()
             self.deepest_depth = max(self.deepest_depth, state.dungeon_depth)
             self.last_depth = state.dungeon_depth
 
@@ -508,6 +511,13 @@ class DecisionEngine:
         if not self.goal_stack:
             heading = KEY_TO_DIR.get(self.last_action)
             target = self._nearest_unexplored_tile(mpos, heading=heading)
+            # #213 P5.3: If directional search failed, retry headingless.
+            if target is None and heading is not None:
+                target = self._nearest_unexplored_tile(mpos, heading=None)
+            # #213 P5.3: If still None but frontier exists, tiles are
+            # unreachable — mark them all as failed so we stop retrying.
+            if target is None and self.unexplored_tiles:
+                self.failed_goals |= self.unexplored_tiles
             if target:
                 self.goal_stack.append(("unexplored", target))
 
@@ -529,8 +539,22 @@ class DecisionEngine:
                 dkey = pf.DIR_TO_KEY.get((nxt[0] - mpos[0], nxt[1] - mpos[1]))
                 if dkey and self._can_step(grid, pos, dkey):
                     return self._record_decision(dkey, "wander_center")
+            # #213 P5.2: Anti-oscillation — avoid directions leading
+            # back to recently-visited positions.
+            recent = set(self._recent_positions)
+            # First pass: try directions that don't revisit recent tiles.
             for key in "ljkhyubn":
                 if self._can_step(grid, pos, key):
+                    d = KEY_TO_DIR.get(key)
+                    if d:
+                        npos = (mpos[0] + d[0], mpos[1] + d[1])
+                        if npos not in recent:
+                            self._recent_positions.append(mpos)
+                            return self._record_decision(key, f"stuck_fallback_{key}")
+            # Second pass: any walkable direction (all recent — just move).
+            for key in "ljkhyubn":
+                if self._can_step(grid, pos, key):
+                    self._recent_positions.append(mpos)
                     return self._record_decision(key, f"stuck_fallback_{key}")
             return self._record_decision(".", "idle_wait")
 

--- a/scripts/bot/pathfinding.py
+++ b/scripts/bot/pathfinding.py
@@ -16,9 +16,9 @@ DIR_TO_KEY = {
 
 WALKABLE = {".", "'", "<", ">", "@"}
 SOLID = {"#", ":"}
-UNSEEN = {" ", "~"}  # screen space or known_map unseen sentinel
+UNSEEN = {" ", "\x00"}  # screen space or known_map unseen sentinel
 
-# Unseen tiles (" " on screen, "~" in known_map) and closed doors ("+")
+# Unseen tiles (" " on screen, "\x00" in known_map) and closed doors ("+")
 # are neither WALKABLE nor SOLID — traversable but expensive for A*.
 UNKNOWN_COST = 5
 DOOR_COST = 3  # ~3 actions to open a door (command + direction + step)

--- a/scripts/crawler.py
+++ b/scripts/crawler.py
@@ -48,7 +48,7 @@ _snap_file = "/tmp/jmoria_snap.txt"
 
 
 def _create_think_pane(session: str) -> bool:
-    """Create a 3-row bottom strip split left (think) / right (snapshot)."""
+    """Create a 5-row bottom strip split left (think) / right (snapshot)."""
     global _think_pane_id, _snap_pane_id
     # Seed files.
     with open(_think_file, "w") as f:
@@ -57,7 +57,7 @@ def _create_think_pane(session: str) -> bool:
         f.write("(awaiting first snapshot)\n")
     # Left pane: per-turn think status.
     result = subprocess.run(
-        ["tmux", "split-window", "-t", f"{session}:0.0", "-v", "-l", "3",
+        ["tmux", "split-window", "-t", f"{session}:0.0", "-v", "-l", "5",
          "-d", "-P", "-F", "#{pane_id}",
          "sh", "-c", f"while true; do clear; cat {_think_file}; sleep 0.3; done"],
         capture_output=True, text=True,
@@ -238,6 +238,9 @@ def run_loop(verbose: bool = False, knowledge_file: str = "", think: bool = Fals
 
     while True:
         state = screen.read(state=prev_state, dungeon_depth=depth)
+        # #206: Sync local depth from the stats-panel parse so the log
+        # reflects the actual depth even when staircase messages are missed.
+        depth = state.dungeon_depth
         turn += 1
 
         # Track dungeon depth from messages
@@ -329,6 +332,7 @@ def run_loop(verbose: bool = False, knowledge_file: str = "", think: bool = Fals
                 f"[turn {turn:5d}] HP={state.player_hp}/{state.player_max_hp} "
                 f"depth={depth} wpos={state.player_world_pos} "
                 f"monsters={len(state.monsters)} items={len(state.items)} "
+                f"unx={len(engine.unexplored_tiles)} "
                 f"think={thought!r}{parse_note} msg={msg_display!r:40s} -> {action!r}"
             )
 


### PR DESCRIPTION
Adds the work list for #213 — "happy wanderer" exploration improvements.

This PR contains **only the WORKLIST file** to establish the plan before implementation begins.

## Priority tiers

1. **Direction-biased target selection** — bias `_nearest_unexplored_tile()` toward continuing in the current travel direction; reduce backtracking near doors
2. **Frontier clustering** — group contiguous frontier tiles into clusters and commit to clearing one before switching
3. **Door proximity boost** — boost score for doors adjacent to current path
4. **Measurement & validation** — add exploration efficiency metrics, baseline current behavior, validate improvements
5. **Edge cases & polish** — dark room sweep, oscillation hysteresis, graceful DFS fallback

Closes: n/a (plan only — #213 remains open for implementation)