### PR TITLE
fix: render player-facing element name in elemental-hit message

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -779,6 +779,31 @@ public:
         return "(none)";
     }
 
+    // Return a player-facing element name for a single EFFECT_FLAG bit
+    // (e.g. EFFECT_FLAG_FIRE -> "fire"). The string-table lookup returns
+    // the raw macro name ("EFFECT_FLAG_FIRE"), which is fine for log
+    // output but leaks into player-visible text — see issue #294, where
+    // the "strikes the X with %s" message printed "EFFECT_FLAG_FIRE"
+    // instead of "fire".
+    const char *Element( uint32 dwFlag )
+    {
+        switch( dwFlag )
+        {
+        case EFFECT_FLAG_FIRE:        return "fire";
+        case EFFECT_FLAG_COLD:        return "cold";
+        case EFFECT_FLAG_ELECTRICITY: return "electricity";
+        case EFFECT_FLAG_ACID:        return "acid";
+        case EFFECT_FLAG_POISON:      return "poison";
+        case EFFECT_FLAG_LIGHT:       return "light";
+        case EFFECT_FLAG_PARALYZE:    return "paralysis";
+        case EFFECT_FLAG_AFRAID:      return "fear";
+        case EFFECT_FLAG_BLIND:       return "blindness";
+        case EFFECT_FLAG_SLEEP:       return "sleep";
+        case EFFECT_FLAG_CONFUSE:     return "confusion";
+        default:                      return "an unknown force";
+        }
+    }
+
     const char *PotionColor( const uint32 dwIndex )
     {
         if( dwIndex >= NUM_POTION_TYPES )

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1478,11 +1478,14 @@ JResult CPlayer::DoElementalHit( CEffect *pEffect )
     // Save monster name before it's potentially deleted
     const char *szMonName = pMon->GetName();
 
-    // Print effect description message
+    // Print effect description message. szElement above is the raw macro
+    // name ("EFFECT_FLAG_FIRE") which is correct for the JLog line but
+    // would leak into player-visible text — see #294. Use Element() to
+    // get the player-facing element noun ("fire") for the message.
     if( pEffect->m_ed && pEffect->m_ed->m_szName )
     {
         g_pGame->GetMsgs()->Printf( "The %s strikes the %s with %s.\n", pEffect->m_ed->m_szName,
-                                    szMonName, szElement );
+                                    szMonName, g_Constants.Element( pEffect->m_dwFlags ) );
     }
 
     const char *szAmount = pEffect->m_szAmount;


### PR DESCRIPTION
## Summary

Closes #294.

The \"\`The X strikes the Y with %s.\`\" message in
\`Player::DoElementalHit\` was printing the raw \`EFFECT_FLAG\` macro
name (e.g. \`EFFECT_FLAG_FIRE\`) because the only conversion available
was \`g_Constants.IndexToString( EFFECT_FLAG, ... )\`, which returns
the literal symbol used in the string table. That's the right value
for the surrounding \`JLog\` line and for save/load round-trips, but
it leaks into player-visible text.

## Fix

Add \`Constants::Element( uint32 dwFlag )\` that maps a single
\`EFFECT_FLAG\` bit to a player-facing noun:

| Flag | Noun |
| --- | --- |
| \`EFFECT_FLAG_FIRE\` | \`\"fire\"\` |
| \`EFFECT_FLAG_COLD\` | \`\"cold\"\` |
| \`EFFECT_FLAG_ELECTRICITY\` | \`\"electricity\"\` |
| \`EFFECT_FLAG_ACID\` | \`\"acid\"\` |
| \`EFFECT_FLAG_POISON\` | \`\"poison\"\` |
| \`EFFECT_FLAG_LIGHT\` | \`\"light\"\` |
| \`EFFECT_FLAG_PARALYZE\` | \`\"paralysis\"\` |
| \`EFFECT_FLAG_AFRAID\` | \`\"fear\"\` |
| \`EFFECT_FLAG_BLIND\` | \`\"blindness\"\` |
| \`EFFECT_FLAG_SLEEP\` | \`\"sleep\"\` |
| \`EFFECT_FLAG_CONFUSE\` | \`\"confusion\"\` |
| anything else | \`\"an unknown force\"\` |

\`Player::DoElementalHit\` now feeds \`pEffect->m_dwFlags\` through
\`Constants::Element(...)\` for the message line; the existing
\`JLog\` line keeps using \`IndexToString(EFFECT_FLAG, …)\` so debug
output is unaffected.

## Test plan

- \`make ascii\` builds clean with the change applied.
- Existing string-table tests in \`test/features/effects.feature\`
  still reference \`EFFECT_FLAG_FIRE\` against \`IndexToString\` /
  \`LookupEffectFlag\`, which are unchanged.
- I didn't add a unit test for \`Element\` because the project's test
  harness is a Cucumber-cpp suite that I can't run here without the
  Boost / cucumber-cpp toolchain. Happy to add a feature step for
  \`Element\` if you'd like.